### PR TITLE
Untaint K8s master for single node setups

### DIFF
--- a/system/scripts/kubeadm/vick-init-kubeadm.sh
+++ b/system/scripts/kubeadm/vick-init-kubeadm.sh
@@ -34,6 +34,10 @@
 #Initialize the k8s cluster
 #kubeadm init --pod-network-cidr=10.244.0.0/16
 
+#if you are using a single node which acts as both a master and a worker
+#untaint the node so that pods will get scheduled:
+#kubectl taint nodes --all node-role.kubernetes.io/master-
+
 #if you get an error similar to 
 #'[ERROR Swap]: running with swap on is not supported. Please disable swap', disable swap:
 #swapoff -a


### PR DESCRIPTION
## Purpose
> If a single node is used as both master and worker, need to untaint the master so pods will get scheduled in it.