### PR TITLE
Read cell-gateway hostname from config map & Add X_THROTTLING_TIER filed

### DIFF
--- a/system/control-plane/cell/components/global-api-updater/src/main/java/org/wso2/vick/apiupdater/UpdateManager.java
+++ b/system/control-plane/cell/components/global-api-updater/src/main/java/org/wso2/vick/apiupdater/UpdateManager.java
@@ -346,8 +346,7 @@ public class UpdateManager {
     private static String getGlobalEndpoint() {
         String response = Constants.Utils.EMPTY_STRING;
         ProductionEndpoint productionEndpoint = new ProductionEndpoint();
-        productionEndpoint.setUrl(Constants.Utils.HTTP + cellConfig.getCell() + Constants.Utils.HYPHEN +
-                                  Constants.Utils.GATEWAY_SERVICE);
+        productionEndpoint.setUrl(Constants.Utils.HTTP + cellConfig.getHostname());
 
         Endpoint endpoint = new Endpoint();
         endpoint.setProductionEndPoint(productionEndpoint);

--- a/system/control-plane/cell/components/global-api-updater/src/main/java/org/wso2/vick/apiupdater/beans/controller/Cell.java
+++ b/system/control-plane/cell/components/global-api-updater/src/main/java/org/wso2/vick/apiupdater/beans/controller/Cell.java
@@ -35,6 +35,9 @@ public class Cell {
     @JsonProperty(Constants.JsonParamNames.APIS)
     private API[] apis;
 
+    @JsonProperty(Constants.JsonParamNames.HOSTNAME)
+    private String hostname;
+
     public String getCell() {
         return cell;
     }
@@ -57,5 +60,13 @@ public class Cell {
 
     public void setApis(API[] apis) {
         this.apis = apis;
+    }
+
+    public String getHostname() {
+        return hostname;
+    }
+
+    public void setHostname(String hostname) {
+        this.hostname = hostname;
     }
 }

--- a/system/control-plane/cell/components/global-api-updater/src/main/java/org/wso2/vick/apiupdater/beans/request/Method.java
+++ b/system/control-plane/cell/components/global-api-updater/src/main/java/org/wso2/vick/apiupdater/beans/request/Method.java
@@ -36,8 +36,12 @@ public class Method {
     @JsonProperty(Constants.JsonParamNames.X_AUTH_TYPE)
     private String xAuthType;
 
+    @JsonProperty(Constants.JsonParamNames.X_THROTTLING_TIER)
+    private String xThrottlingTier;
+
     public Method() {
-        this.xAuthType = "None";
+        this.xAuthType = "Application & Application User";
+        this.xThrottlingTier = "Unlimited";
     }
 
     public List<Parameter> getParameters() {
@@ -54,5 +58,13 @@ public class Method {
 
     public void setxAuthType(String xAuthType) {
         this.xAuthType = xAuthType;
+    }
+
+    public String getxThrottlingTier() {
+        return xThrottlingTier;
+    }
+
+    public void setxThrottlingTier(String xThrottlingTier) {
+        this.xThrottlingTier = xThrottlingTier;
     }
 }

--- a/system/control-plane/cell/components/global-api-updater/src/main/java/org/wso2/vick/apiupdater/utils/Constants.java
+++ b/system/control-plane/cell/components/global-api-updater/src/main/java/org/wso2/vick/apiupdater/utils/Constants.java
@@ -60,6 +60,7 @@ public class Constants {
         public static final String ACCESS_URLS = "accessUrls";
         public static final String PARAMETERS = "parameters";
         public static final String X_AUTH_TYPE = "x-auth-type";
+        public static final String X_THROTTLING_TIER = "x-throttling-tier";
         public static final String REQUIRED = "required";
         public static final String IN = "in";
         public static final String GET = "get";

--- a/system/control-plane/cell/components/global-api-updater/src/main/java/org/wso2/vick/apiupdater/utils/Constants.java
+++ b/system/control-plane/cell/components/global-api-updater/src/main/java/org/wso2/vick/apiupdater/utils/Constants.java
@@ -42,6 +42,7 @@ public class Constants {
         public static final String API_VERSION = "apiVersion";
         public static final String REGISTER_PAYLOAD = "registerPayload";
         public static final String TRUST_STORE = "trustStore";
+        public static final String HOSTNAME = "hostname";
         public static final String APIM_BASE_URL = "apimBaseUrl";
         public static final String TOKEN_ENDPOINT = "tokenEndpoint";
         public static final String NAME = "name";


### PR DESCRIPTION
* Read cell-gateway hostname from config map to avoid inconsistencies in the future.
* Add X_THROTTLING_TIER filed for API definition json file since there is no any default value for the throttling tier in the database.