### PR TITLE
Improve Cell STS to pass user context across service calls

### DIFF
--- a/system/control-plane/cell/components/cell-sts/pom.xml
+++ b/system/control-plane/cell/components/cell-sts/pom.xml
@@ -100,17 +100,6 @@
             <version>${grpc.version}</version>
         </dependency>
         <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-testing</artifactId>
-            <version>${grpc.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.httpcomponents</groupId>
-            <artifactId>httpclient</artifactId>
-            <version>4.5.6</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
             <version>2.11.1</version>
@@ -125,6 +114,12 @@
                     <artifactId>org.wso2.vick.auth.extensions</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>LATEST</version>
+            <scope>compile</scope>
         </dependency>
     </dependencies>
 

--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/VickCellSTSServer.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/VickCellSTSServer.java
@@ -4,7 +4,7 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.wso2.vick.auth.cell.sts.service.VickCellOutboundAuthorizationService;
+import org.wso2.vick.auth.cell.sts.service.VickCellAuthorizationService;
 import org.wso2.vick.auth.cell.sts.service.VickCellSTSException;
 
 import java.io.IOException;
@@ -21,7 +21,7 @@ public class VickCellSTSServer {
     private VickCellSTSServer(int port) throws VickCellSTSException {
 
         this.port = port;
-        server = ServerBuilder.forPort(port).addService(new VickCellOutboundAuthorizationService()).build();
+        server = ServerBuilder.forPort(port).addService(new VickCellAuthorizationService()).build();
     }
 
     /**


### PR DESCRIPTION
* Intercept inbound side car HTTP calls
  This allows us to store the original JWT sent to gateway and to inject user attribute headers to be consumed by the downstream services

* Use the stored JWT token in user context store for outbound calls.
