### PR TITLE
Change authentication context information header names

### DIFF
--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellInboundInterceptorService.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellInboundInterceptorService.java
@@ -81,7 +81,7 @@ public class VickCellInboundInterceptorService extends VickCellInterceptorServic
 
         return ExternalAuth.CheckResponse.newBuilder()
                 .setStatus(Status.newBuilder().setCode(Code.OK_VALUE).build())
-                .setOkResponse(buildOkHttpResponse(headersToSet))
+                .setOkResponse(buildOkHttpResponseWithHeaders(headersToSet))
                 .build();
     }
 

--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellInboundInterceptorService.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellInboundInterceptorService.java
@@ -37,8 +37,8 @@ import java.util.Map;
  */
 public class VickCellInboundInterceptorService extends VickCellInterceptorService {
 
-    private static final String VICK_AUTH_USER_HEADER = "x-vick-auth-user";
-    private static final String VICK_AUTH_USER_CLAIMS_HEADER = "x-vick-auth-user-claims";
+    private static final String VICK_AUTH_SUBJECT_HEADER = "x-vick-auth-subject";
+    private static final String VICK_AUTH_SUBJECT_CLAIMS_HEADER = "x-vick-auth-subject-claims";
 
     private Logger log = LoggerFactory.getLogger(VickCellInboundInterceptorService.class);
 
@@ -76,8 +76,8 @@ public class VickCellInboundInterceptorService extends VickCellInterceptorServic
         }
 
         Map<String, String> headersToSet = new HashMap<>();
-        headersToSet.put(VICK_AUTH_USER_HEADER, jwtClaims.getSubject());
-        headersToSet.put(VICK_AUTH_USER_CLAIMS_HEADER, new PlainJWT(jwtClaims).serialize());
+        headersToSet.put(VICK_AUTH_SUBJECT_HEADER, jwtClaims.getSubject());
+        headersToSet.put(VICK_AUTH_SUBJECT_CLAIMS_HEADER, new PlainJWT(jwtClaims).serialize());
 
         return ExternalAuth.CheckResponse.newBuilder()
                 .setStatus(Status.newBuilder().setCode(Code.OK_VALUE).build())

--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellInterceptorService.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellInterceptorService.java
@@ -132,11 +132,11 @@ public abstract class VickCellInterceptorService extends AuthorizationGrpc.Autho
 
     protected ExternalAuth.OkHttpResponse buildOkHttpResponse(String stsToken) {
 
-        return buildOkHttpResponse(
+        return buildOkHttpResponseWithHeaders(
                 Collections.singletonMap(AUTHORIZATION_HEADER_NAME, BEARER_HEADER_VALUE_PREFIX + stsToken));
     }
 
-    protected ExternalAuth.OkHttpResponse buildOkHttpResponse(Map<String, String> headers) {
+    protected ExternalAuth.OkHttpResponse buildOkHttpResponseWithHeaders(Map<String, String> headers) {
 
         ExternalAuth.OkHttpResponse.Builder builder = ExternalAuth.OkHttpResponse.newBuilder();
         headers.forEach((key, value) -> builder.addHeaders(buildHeader(key, value)));


### PR DESCRIPTION
$subject since within the cell, the cell STS handle both user and service authentication. Therefore it would be more meaningful to change the header names to reflect a common name.