### PR TITLE
Improve Vick Security Flow

### DIFF
--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/CellStsUtils.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/CellStsUtils.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package org.wso2.vick.auth.cell.sts;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import org.apache.commons.lang.StringUtils;
+import org.json.simple.JSONObject;
+import org.wso2.vick.auth.cell.sts.service.VickCellSTSException;
+
+import java.util.Map;
+
+public class CellStsUtils {
+
+    private static final String CELL_NAME_ENV_VARIABLE = "CELL_NAME";
+
+    public static String getMyCellName() throws VickCellSTSException {
+        // For now we pick the cell name from the environment variable.
+        String cellName = System.getenv(CELL_NAME_ENV_VARIABLE);
+        if (StringUtils.isBlank(cellName)) {
+            throw new VickCellSTSException("Environment variable '" + CELL_NAME_ENV_VARIABLE + "' is empty.");
+        }
+        return cellName;
+    }
+
+    public static boolean isWorkloadExternalToVick(String destinationWorkloadName) {
+        // For now the only way to check whether the destination is outside of VICK/Cell mesh is by checking whether the
+        // destination workload name does not comply to the format <cell-name>--<service_name>
+        // Eg: hr--employee-service
+        // Once we find a smarter way to check whether the target is outside of VICK we can replace this not-so-smart
+        // logic.
+        return !StringUtils.contains(destinationWorkloadName, "--");
+    }
+
+    public static String getPrettyPrintJson(Map<String, String> attributes) {
+        JSONObject configJson = new JSONObject();
+        attributes.forEach((key, value) -> configJson.put(key, value));
+
+        Gson gson = new GsonBuilder().setPrettyPrinting().create();
+        return gson.toJson(configJson);
+    }
+}

--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/model/CellStsRequest.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/model/CellStsRequest.java
@@ -18,19 +18,16 @@
  */
 package org.wso2.vick.auth.cell.sts.model;
 
-import org.wso2.vick.auth.cell.sts.generated.envoy.service.auth.v2alpha.AttributeContextOuterClass;
-import org.wso2.vick.auth.cell.sts.generated.envoy.service.auth.v2alpha.ExternalAuth;
-
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
 public class CellStsRequest {
 
+    private String requestId;
     private RequestSource source;
     private RequestDestination destination;
     private RequestContext requestContext;
-
     private Map<String, String> requestHeaders = new HashMap<>();
 
     public RequestSource getSource() {
@@ -49,22 +46,57 @@ public class CellStsRequest {
         return Collections.unmodifiableMap(requestHeaders);
     }
 
-    public CellStsRequest(ExternalAuth.CheckRequest request) {
-
-        requestHeaders.putAll(request.getAttributes().getRequest().getHttp().getHeadersMap());
-        requestContext = buildRequestContext(request);
+    public String getRequestId() {
+        return requestId;
     }
 
-
-    private RequestContext buildRequestContext(ExternalAuth.CheckRequest checkRequest) {
-
-        AttributeContextOuterClass.AttributeContext.HttpRequest httpRequest =
-                checkRequest.getAttributes().getRequest().getHttp();
-
-        return new RequestContext()
-                .setHost(httpRequest.getHost())
-                .setProtocol(httpRequest.getProtocol())
-                .setMethod(httpRequest.getMethod())
-                .setPath(httpRequest.getPath());
+    private CellStsRequest() {
     }
+
+    public static class CellStsRequestBuilder {
+
+        private String requestId;
+        private RequestSource source;
+        private RequestDestination destination;
+        private RequestContext requestContext;
+        private Map<String, String> requestHeaders = new HashMap<>();
+
+
+        public CellStsRequestBuilder setSource(RequestSource source) {
+            this.source = source;
+            return this;
+        }
+
+        public CellStsRequestBuilder setDestination(RequestDestination destination) {
+            this.destination = destination;
+            return this;
+        }
+
+        public CellStsRequestBuilder setRequestContext(RequestContext requestContext) {
+            this.requestContext = requestContext;
+            return this;
+        }
+
+        public CellStsRequestBuilder setRequestHeaders(Map<String, String> requestHeaders) {
+            this.requestHeaders = requestHeaders;
+            return this;
+        }
+
+        public CellStsRequestBuilder setRequestId(String requestId) {
+            this.requestId = requestId;
+            return this;
+        }
+
+        public CellStsRequest build() {
+            CellStsRequest request = new CellStsRequest();
+            request.requestId = requestId;
+            request.source = source;
+            request.destination = destination;
+            request.requestContext = requestContext;
+            request.requestHeaders = requestHeaders;
+
+            return request;
+        }
+     }
+
 }

--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/model/RequestContext.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/model/RequestContext.java
@@ -61,4 +61,6 @@ public class RequestContext {
         this.method = method;
         return this;
     }
+
+    // TODO builder
 }

--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/model/RequestDestination.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/model/RequestDestination.java
@@ -18,25 +18,68 @@
  */
 package org.wso2.vick.auth.cell.sts.model;
 
+import org.wso2.vick.auth.cell.sts.CellStsUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
 public class RequestDestination {
 
     private String cellName;
-
     private String workload;
+    private boolean isExternalToVick;
+
+    private RequestDestination() {
+    }
 
     public String getCellName() {
         return cellName;
-    }
-
-    public void setCellName(String cellName) {
-        this.cellName = cellName;
     }
 
     public String getWorkload() {
         return workload;
     }
 
-    public void setWorkload(String workload) {
-        this.workload = workload;
+    public boolean isExternalToVick() {
+        return isExternalToVick;
+    }
+
+    @Override
+    public String toString() {
+        Map<String, String> configJson = new HashMap<>();
+        configJson.put("Cell Name", cellName);
+        configJson.put("Workload", workload);
+
+        return CellStsUtils.getPrettyPrintJson(configJson);
+    }
+
+    public static class RequestDestinationBuilder {
+        private String cellName;
+        private String workload;
+        private boolean isExternalToVick;
+
+        public RequestDestinationBuilder setCellName(String cellName) {
+            this.cellName = cellName;
+            return this;
+        }
+
+        public RequestDestinationBuilder setWorkload(String workload) {
+            this.workload = workload;
+            return this;
+        }
+
+        public RequestDestinationBuilder setExternalToVick(boolean externalToVick) {
+            isExternalToVick = externalToVick;
+            return this;
+        }
+
+        public RequestDestination build() {
+            RequestDestination destination = new RequestDestination();
+            destination.cellName = cellName;
+            destination.workload = workload;
+            destination.isExternalToVick = isExternalToVick;
+
+            return destination;
+        }
     }
 }

--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/model/RequestSource.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/model/RequestSource.java
@@ -18,25 +18,55 @@
  */
 package org.wso2.vick.auth.cell.sts.model;
 
+import org.wso2.vick.auth.cell.sts.CellStsUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+
 public class RequestSource {
 
     private String cellName;
-
     private String workload;
+
+    private RequestSource() {
+    }
 
     public String getCellName() {
         return cellName;
-    }
-
-    public void setCellName(String cellName) {
-        this.cellName = cellName;
     }
 
     public String getWorkload() {
         return workload;
     }
 
-    public void setWorkload(String workload) {
-        this.workload = workload;
+    @Override
+    public String toString() {
+        Map<String, String> configJson = new HashMap<>();
+        configJson.put("Cell Name", cellName);
+        configJson.put("Workload", workload);
+
+        return CellStsUtils.getPrettyPrintJson(configJson);
+    }
+
+    public static class RequestSourceBuilder {
+        private String cellName;
+        private String workload;
+
+        public RequestSourceBuilder setWorkload(String workload) {
+            this.workload = workload;
+            return this;
+        }
+
+        public RequestSourceBuilder setCellName(String cellName) {
+            this.cellName = cellName;
+            return this;
+        }
+
+        public RequestSource build() {
+            RequestSource requestSource = new RequestSource();
+            requestSource.cellName = cellName;
+            requestSource.workload = workload;
+            return requestSource;
+        }
     }
 }

--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/model/config/CellStsConfiguration.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/model/config/CellStsConfiguration.java
@@ -18,9 +18,10 @@
  */
 package org.wso2.vick.auth.cell.sts.model.config;
 
-import com.google.gson.Gson;
-import com.google.gson.GsonBuilder;
-import org.json.simple.JSONObject;
+import org.wso2.vick.auth.cell.sts.CellStsUtils;
+
+import java.util.HashMap;
+import java.util.Map;
 
 public class CellStsConfiguration {
 
@@ -70,11 +71,10 @@ public class CellStsConfiguration {
 
     @Override
     public String toString() {
-        JSONObject configJson = new JSONObject();
+        Map<String, String> configJson = new HashMap<>();
         configJson.put("Global STS Endpoint", stsEndpoint);
         configJson.put("Cell Name", cellName);
 
-        Gson gson = new GsonBuilder().setPrettyPrinting().create();
-        return gson.toJson(configJson);
+        return CellStsUtils.getPrettyPrintJson(configJson);
     }
 }

--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellInboundInterceptorService.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellInboundInterceptorService.java
@@ -39,7 +39,8 @@ public class VickCellInboundInterceptorService extends VickCellInterceptorServic
     protected void handleRequest(CellStsRequest cellStsRequest,
                                  CellStsResponse cellStsResponse) throws VickCellSTSException {
 
-        log.info("Intercepting Sidecar Inbound call to destination:{}", getDestination(cellStsRequest));
+        log.debug("Intercepted Sidecar Inbound Request:\nSource:{}\nDestination:{}\n", cellStsRequest.getSource(),
+                cellStsRequest.getDestination());
         cellStsService.handleInboundRequest(cellStsRequest, cellStsResponse);
     }
 

--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellInterceptorService.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellInterceptorService.java
@@ -18,6 +18,7 @@
  */
 package org.wso2.vick.auth.cell.sts.service;
 
+import com.google.protobuf.InvalidProtocolBufferException;
 import com.google.rpc.Code;
 import com.google.rpc.Status;
 import io.grpc.stub.StreamObserver;
@@ -25,12 +26,20 @@ import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.wso2.vick.auth.cell.sts.CellStsUtils;
 import org.wso2.vick.auth.cell.sts.generated.envoy.core.Base;
+import org.wso2.vick.auth.cell.sts.generated.envoy.service.auth.v2alpha.AttributeContextOuterClass;
 import org.wso2.vick.auth.cell.sts.generated.envoy.service.auth.v2alpha.AuthorizationGrpc;
 import org.wso2.vick.auth.cell.sts.generated.envoy.service.auth.v2alpha.ExternalAuth;
+import org.wso2.vick.auth.cell.sts.generated.istio.mixer.v1.AttributesOuterClass;
 import org.wso2.vick.auth.cell.sts.model.CellStsRequest;
 import org.wso2.vick.auth.cell.sts.model.CellStsResponse;
+import org.wso2.vick.auth.cell.sts.model.RequestContext;
+import org.wso2.vick.auth.cell.sts.model.RequestDestination;
+import org.wso2.vick.auth.cell.sts.model.RequestSource;
 
+import java.util.Base64;
+import java.util.Collections;
 import java.util.Map;
 
 /**
@@ -48,6 +57,7 @@ public abstract class VickCellInterceptorService extends AuthorizationGrpc.Autho
     private static final String REQUEST_ID_HEADER = "x-request-id";
     private static final String DESTINATION_HEADER = ":authority";
     private static final String CELL_NAME_ENV_VARIABLE = "CELL_NAME";
+    private static final String ISTIO_ATTRIBUTES_HEADER = "x-istio-attributes";
 
     protected VickCellStsService cellStsService;
 
@@ -71,7 +81,17 @@ public abstract class VickCellInterceptorService extends AuthorizationGrpc.Autho
             log.debug("Request from Istio-Proxy (destination:{}):\n{}", destination, requestFromProxy);
 
             // Build Cell STS request from the Envoy Proxy Check Request
-            CellStsRequest cellStsRequest = new CellStsRequest(requestFromProxy);
+            CellStsRequest cellStsRequest = buildCellStsRequest(requestFromProxy);
+
+            AttributesOuterClass.Attributes attributesFromRequest = getAttributesFromRequest(requestFromProxy);
+            Map<String, AttributesOuterClass.Attributes.AttributeValue> attributesMap;
+            if (attributesFromRequest != null) {
+                attributesMap = attributesFromRequest.getAttributesMap();
+            } else {
+                attributesMap = Collections.emptyMap();
+            }
+
+            log.debug("Request Attributes: \n" + attributesMap);
             CellStsResponse cellStsResponse = new CellStsResponse();
 
             // Let the request be handled by inbound/outbound interceptors
@@ -160,4 +180,87 @@ public abstract class VickCellInterceptorService extends AuthorizationGrpc.Autho
         return cellName;
     }
 
+    private CellStsRequest buildCellStsRequest(ExternalAuth.CheckRequest requestFromProxy) throws VickCellSTSException {
+
+        return new CellStsRequest.CellStsRequestBuilder()
+                .setRequestId(getRequestId(requestFromProxy))
+                .setRequestHeaders(requestFromProxy.getAttributes().getRequest().getHttp().getHeaders())
+                .setSource(buildRequestSource(requestFromProxy))
+                .setDestination(buildRequestDestination(requestFromProxy))
+                .setRequestContext(buildRequestContext(requestFromProxy))
+                .build();
+    }
+
+    private AttributesOuterClass.Attributes getAttributesFromRequest(ExternalAuth.CheckRequest requestFromProxy) {
+
+        String mixerAttributesHeaderValue = getMixerAttributesHeader(requestFromProxy);
+
+        if (StringUtils.isNotBlank(mixerAttributesHeaderValue)) {
+            byte[] decodeHeader = Base64.getDecoder().decode(mixerAttributesHeaderValue.getBytes());
+            try {
+                return AttributesOuterClass.Attributes.parseFrom(decodeHeader);
+            } catch (InvalidProtocolBufferException e) {
+                log.error("Error while trying to decode mixer attributes from '{}' header", ISTIO_ATTRIBUTES_HEADER);
+            }
+        }
+        return null;
+    }
+
+    private String getMixerAttributesHeader(ExternalAuth.CheckRequest requestFromProxy) {
+        return requestFromProxy.getAttributes().getRequest().getHttp().getHeadersMap().get(ISTIO_ATTRIBUTES_HEADER);
+    }
+
+    private RequestContext buildRequestContext(ExternalAuth.CheckRequest checkRequest) {
+
+        AttributeContextOuterClass.AttributeContext.HttpRequest httpRequest =
+                checkRequest.getAttributes().getRequest().getHttp();
+
+        return new RequestContext()
+                .setHost(httpRequest.getHost())
+                .setProtocol(httpRequest.getProtocol())
+                .setMethod(httpRequest.getMethod())
+                .setPath(httpRequest.getPath());
+    }
+
+    private RequestSource buildRequestSource(ExternalAuth.CheckRequest checkRequest) {
+//        AttributesOuterClass.Attributes attributesFromRequest = getAttributesFromRequest(checkRequest);
+        RequestSource.RequestSourceBuilder requestSourceBuilder = new RequestSource.RequestSourceBuilder();
+//        if (attributesFromRequest != null) {
+//            AttributesOuterClass.Attributes.AttributeValue sourceId =
+//                    attributesFromRequest.getAttributesMap().get("source.uid");
+//            if (sourceId != null) {
+//                // "source.uid" -> "kubernetes://hr--hr-deployment-596946948d-vvgln.default"
+//                String sourceUid = sourceId.getStringValue();
+//                String sourceWorkloadName = sourceUid.replace("kubernetes://", "");
+//
+//                requestSourceBuilder.setWorkload(sourceWorkloadName)
+//                        .setCellName(extractCellNameFromWorkloadName(sourceWorkloadName));
+//            }
+//        }
+        return requestSourceBuilder.build();
+    }
+
+    private String extractCellNameFromWorkloadName(String workloadName) {
+        // Workload name is in the format hr--hr-deployment-596946948d-vvgln.default where the value before --
+        // is the cell name.
+        return workloadName.split("--")[0];
+    }
+
+    private RequestDestination buildRequestDestination(ExternalAuth.CheckRequest checkRequest) {
+        RequestDestination.RequestDestinationBuilder destinationBuilder =
+                new RequestDestination.RequestDestinationBuilder();
+
+        String destinationWorkloadName = getDestination(checkRequest);
+        if (StringUtils.isNotBlank(destinationWorkloadName)) {
+            destinationBuilder.setWorkload(destinationWorkloadName);
+        }
+
+        if (CellStsUtils.isWorkloadExternalToVick(destinationWorkloadName)) {
+            destinationBuilder.setExternalToVick(true);
+        } else {
+            destinationBuilder.setCellName(extractCellNameFromWorkloadName(destinationWorkloadName));
+        }
+
+        return destinationBuilder.build();
+    }
 }

--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellOutboundInterceptorService.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellOutboundInterceptorService.java
@@ -38,7 +38,8 @@ public class VickCellOutboundInterceptorService extends VickCellInterceptorServi
     protected void handleRequest(CellStsRequest cellStsRequest,
                                  CellStsResponse cellStsResponse) throws VickCellSTSException {
 
-        log.info("Intercepting Sidecar Outbound call to destination:{}", getDestination(cellStsRequest));
+        log.debug("Intercepted Sidecar Outbound Request:\nSource:{}\nDestination:{}\n", cellStsRequest.getSource(),
+                cellStsRequest.getDestination());
         cellStsService.handleOutboundRequest(cellStsRequest, cellStsResponse);
     }
 }

--- a/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellStsService.java
+++ b/system/control-plane/cell/components/cell-sts/src/main/java/org/wso2/vick/auth/cell/sts/service/VickCellStsService.java
@@ -31,9 +31,11 @@ import org.apache.http.impl.client.HttpClients;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.wso2.vick.auth.cell.sts.CellStsUtils;
 import org.wso2.vick.auth.cell.sts.context.store.UserContextStore;
 import org.wso2.vick.auth.cell.sts.model.CellStsRequest;
 import org.wso2.vick.auth.cell.sts.model.CellStsResponse;
+import org.wso2.vick.auth.cell.sts.model.RequestDestination;
 import org.wso2.vick.auth.cell.sts.model.config.CellStsConfiguration;
 import org.wso2.vick.sts.core.VickSTSConstants;
 
@@ -45,7 +47,6 @@ import java.util.Map;
 
 public class VickCellStsService {
 
-    private static final String REQUEST_ID_HEADER = "x-request-id";
     private static final String VICK_AUTH_SUBJECT_HEADER = "x-vick-auth-subject";
     private static final String VICK_AUTH_SUBJECT_CLAIMS_HEADER = "x-vick-auth-subject-claims";
     private static final String AUTHORIZATION_HEADER_NAME = "authorization";
@@ -70,7 +71,7 @@ public class VickCellStsService {
                                      CellStsResponse cellStsResponse) throws VickCellSTSException {
 
         // Extract the requestId
-        String requestId = getRequestId(cellStsRequest);
+        String requestId = cellStsRequest.getRequestId();
 
         JWTClaimsSet jwtClaims;
         if (userContextStore.containsKey(requestId)) {
@@ -84,11 +85,11 @@ public class VickCellStsService {
             // authorization header and store it in our user context store.
             log.debug("User context JWT not found in context store for requestId:{}. " +
                     "Extracting the user context JWT from the authorization header", requestId);
-            String authzHeaderValue = getAuthorizationHeaderValue(cellStsRequest);
-            jwtClaims = extractUserClaimsFromAuthzHeader(authzHeaderValue);
+            String jwt = getUserContextJwt(cellStsRequest);
+            jwtClaims = extractUserClaimsFromJwt(jwt);
 
             // We store the JWT sent in the authorization header against the request Id
-            userContextStore.put(requestId, authzHeaderValue);
+            userContextStore.put(requestId, jwt);
             log.debug("User context JWT added to context store for requestId:{}", requestId);
         }
 
@@ -99,13 +100,23 @@ public class VickCellStsService {
         cellStsResponse.addResponseHeaders(headersToSet);
     }
 
+    private String getUserContextJwt(CellStsRequest cellStsRequest) {
+        String authzHeaderValue = getAuthorizationHeaderValue(cellStsRequest);
+        return extractJwtFromAuthzHeader(authzHeaderValue);
+    }
+
 
     public void handleOutboundRequest(CellStsRequest cellStsRequest,
                                       CellStsResponse cellStsResponse) throws VickCellSTSException {
 
-        String authzHeaderInRequest = getAuthorizationHeaderValue(cellStsRequest);
-        if (StringUtils.isEmpty(authzHeaderInRequest)) {
-            log.debug("Authorization Header is missing in the outbound call. Injecting a JWT from at cell STS.");
+        // First we check whether the destination of the intercepted call is within VICK
+        RequestDestination destination = cellStsRequest.getDestination();
+        if (destination.isExternalToVick()) {
+            // If the intercepted call is to an external workload to VICK we cannot do anything in the Cell STS.
+            log.info("Intercepted an outbound call to a workload:{} outside VICK. Passing the call through.", destination);
+        } else {
+            log.info("Intercepted an outbound call to a workload:{} within VICK. Injecting a STS token for " +
+                    "authentication and user-context sharing from Cell STS.", destination);
 
             String stsToken = getStsToken(cellStsRequest);
             if (StringUtils.isEmpty(stsToken)) {
@@ -114,9 +125,6 @@ public class VickCellStsService {
             }
             // Set the authorization header
             cellStsResponse.addResponseHeader(AUTHORIZATION_HEADER_NAME, BEARER_HEADER_VALUE_PREFIX + stsToken);
-        } else {
-            log.info("Authorization Header is present in the request. Continuing without injecting a new JWT at " +
-                    "cell STS.");
         }
     }
 
@@ -125,18 +133,8 @@ public class VickCellStsService {
         return request.getRequestHeaders().get(AUTHORIZATION_HEADER_NAME);
     }
 
-    private String getRequestId(CellStsRequest cellStsRequest) throws VickCellSTSException {
+    private JWTClaimsSet extractUserClaimsFromJwt(String jwt) throws VickCellSTSException {
 
-        String id = cellStsRequest.getRequestHeaders().get(REQUEST_ID_HEADER);
-        if (StringUtils.isBlank(id)) {
-            throw new VickCellSTSException("Request Id cannot be found in the header: " + REQUEST_ID_HEADER);
-        }
-        return id;
-    }
-
-    private JWTClaimsSet extractUserClaimsFromAuthzHeader(String authzHeaderValue) throws VickCellSTSException {
-
-        String jwt = extractJwtFromAuthzHeader(authzHeaderValue);
         if (StringUtils.isBlank(jwt)) {
             throw new VickCellSTSException("Cannot extract user context JWT from Authorization header.");
         }
@@ -172,26 +170,49 @@ public class VickCellStsService {
 
         try {
             // Check for a stored user context
-            String requestId = getRequestId(request);
+            String requestId = request.getRequestId();
+            String stsEndpoint = cellStsConfiguration.getStsEndpoint();
             // This is the original JWT sent to the cell gateway.
             String jwt = userContextStore.get(requestId);
 
-            if (StringUtils.isNotBlank(jwt)) {
-                log.debug("JWT token to inject into outbound call was retrieved from the user context store.");
-                return jwt;
+            // Check whether the outbound call is Inter Cell or Intra Cell
+            if (isIntraCellCall(request)) {
+                // We first try to reuse a JWT token cached within the cell.
+                if (StringUtils.isBlank(jwt)) {
+                    log.debug("No JWT was found in the user context store for requestId:{}. " +
+                            "Calling the Global STS endpoint {} to get a JWT for inter cell communication. " +
+                            "Destination:{}.", requestId, stsEndpoint, request.getDestination());
+                    return getTokenFromGlobalSTS(CellStsUtils.getMyCellName());
+                } else {
+                    // We found a JWT cached in the user context store. We are going to reuse it.
+                    log.debug("Found a valid JWT in user context store for requestId:{}. Reusing it.", requestId);
+                    return jwt;
+                }
             } else {
-                // Most probably this is the case where a request has been initiated from within a Cell without a
-                // user interaction.
-                log.debug("User Context JWT cannot be retrieved from the context store." +
-                        "Calling the Global STS endpoint {} to get a JWT.", cellStsConfiguration.getStsEndpoint());
-                return getTokenFromGlobalSTS();
+                // This is an inter cell call. So I need to get a token within the audience set to my destination cell.
+                String destinationCell = request.getDestination().getCellName();
+                log.debug("Requesting a JWT token from the global STS:{} to talk to inter cell communication. " +
+                        "Destination:{}", stsEndpoint, request.getDestination());
+                return getTokenFromGlobalSTS(destinationCell, jwt);
             }
+
         } catch (UnirestException e) {
             throw new VickCellSTSException("Error while obtaining the STS token.", e);
         }
     }
 
-    private String getTokenFromGlobalSTS() throws UnirestException {
+    private boolean isIntraCellCall(CellStsRequest cellStsRequest) throws VickCellSTSException {
+        String currentCell = CellStsUtils.getMyCellName();
+        String destinationCell = cellStsRequest.getDestination().getCellName();
+
+        return StringUtils.equals(currentCell, destinationCell);
+    }
+
+    private String getTokenFromGlobalSTS(String audience) throws UnirestException {
+        return getTokenFromGlobalSTS(audience, null);
+    }
+
+    private String getTokenFromGlobalSTS(String audience, String userContextJwt) throws UnirestException {
 
         String stsEndpointUrl = cellStsConfiguration.getStsEndpoint();
         String username = cellStsConfiguration.getUsername();
@@ -202,6 +223,8 @@ public class VickCellStsService {
                 Unirest.post(stsEndpointUrl)
                         .basicAuth(username, password)
                         .field(VickSTSConstants.VickSTSRequest.SUBJECT, cellName)
+                        .field(VickSTSConstants.VickSTSRequest.USER_CONTEXT_JWT, userContextJwt)
+                        .field(VickSTSConstants.VickSTSRequest.AUDIENCE, audience)
                         .asJson();
 
         log.debug("Response from the STS:\nstatus:{}\nbody:{}",

--- a/system/control-plane/global/components/auth/org.wso2.vick.auth.extensions/pom.xml
+++ b/system/control-plane/global/components/auth/org.wso2.vick.auth.extensions/pom.xml
@@ -65,6 +65,11 @@
             <artifactId>org.wso2.carbon.apimgt.keymgt</artifactId>
             <version>6.4.50</version>
         </dependency>
+        <dependency>
+            <groupId>org.wso2.carbon.apimgt</groupId>
+            <artifactId>org.wso2.carbon.apimgt.impl</artifactId>
+            <version>6.4.50</version>
+        </dependency>
     </dependencies>
 
     <build>

--- a/system/control-plane/global/components/auth/org.wso2.vick.auth.extensions/src/main/java/org/wso2/vick/auth/jwt/VickSignedJWTBuilder.java
+++ b/system/control-plane/global/components/auth/org.wso2.vick.auth.extensions/src/main/java/org/wso2/vick/auth/jwt/VickSignedJWTBuilder.java
@@ -36,11 +36,13 @@ import org.wso2.vick.auth.exception.VickAuthException;
 
 import java.security.Key;
 import java.security.interfaces.RSAPrivateKey;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import java.util.stream.Collectors;
 
 /**
  * The JWT token builder for VICK.
@@ -62,7 +64,7 @@ public class VickSignedJWTBuilder {
 
     // By default we set the expiry to be 20mins (So that it will be greater than GatewayCache timeout)
     private long expiryInSeconds = 1200L;
-    private List<String> audience;
+    private List<String> audience = new ArrayList<>();
 
     public VickSignedJWTBuilder subject(String subject) {
 
@@ -96,6 +98,12 @@ public class VickSignedJWTBuilder {
     public VickSignedJWTBuilder audience(List<String> audience) {
 
         this.audience = audience;
+        return this;
+    }
+
+    public VickSignedJWTBuilder audience(String audience) {
+
+        this.audience.add(audience);
         return this;
     }
 
@@ -161,7 +169,9 @@ public class VickSignedJWTBuilder {
         if (CollectionUtils.isEmpty(audience)) {
             return Collections.singletonList(MICRO_GATEWAY_DEFAULT_AUDIENCE_VALUE);
         } else {
-            return audience;
+            return audience.stream()
+                    .filter(StringUtils::isNotBlank)
+                    .collect(Collectors.toList());
         }
     }
 }

--- a/system/control-plane/global/components/auth/org.wso2.vick.auth.extensions/src/main/java/org/wso2/vick/auth/util/Utils.java
+++ b/system/control-plane/global/components/auth/org.wso2.vick.auth.extensions/src/main/java/org/wso2/vick/auth/util/Utils.java
@@ -18,22 +18,122 @@
 
 package org.wso2.vick.auth.util;
 
+import com.nimbusds.jose.JOSEException;
+import com.nimbusds.jose.JWSVerifier;
+import com.nimbusds.jose.crypto.RSASSAVerifier;
+import com.nimbusds.jwt.SignedJWT;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.application.common.util.IdentityApplicationManagementUtil;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
+import org.wso2.carbon.idp.mgt.IdentityProviderManager;
+import org.wso2.carbon.utils.multitenancy.MultitenantConstants;
+
+import java.security.PublicKey;
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import java.security.interfaces.RSAPublicKey;
+import java.text.ParseException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * This is the Utils class for token validations.
- *
  */
 public class Utils {
 
+    private static final Log log = LogFactory.getLog(Utils.class);
+
     public static final String OPENID_IDP_ENTITY_ID = "IdPEntityId";
+    private static final Set<String> FILTERED_CLAIMS;
+
+    static {
+        Set<String> n = new HashSet<>();
+        n.add("iss");
+        n.add("aud");
+        n.add("exp");
+        n.add("nbf");
+        n.add("iat");
+        n.add("jti");
+        n.add("scope");
+        n.add("keytype");
+
+        FILTERED_CLAIMS = Collections.unmodifiableSet(n);
+    }
 
     private Utils() {
 
     }
 
+    public static IdentityProvider getVickIdp() throws IdentityProviderManagementException {
+        return IdentityProviderManager.getInstance().getResidentIdP(MultitenantConstants.SUPER_TENANT_DOMAIN_NAME);
+    }
+
     public static boolean isSignedJWT(String jwtToTest) {
         // Signed JWT token contains 3 base64 encoded components separated by periods.
         return StringUtils.countMatches(jwtToTest, ".") == 2;
+    }
+
+    public static Map<String, Object> getCustomClaims(SignedJWT signedJWT) throws ParseException {
+        return signedJWT.getJWTClaimsSet().getClaims().entrySet()
+                .stream()
+                .filter(x -> !FILTERED_CLAIMS.contains(x.getKey()))
+                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    public static boolean validateSignature(SignedJWT signedJWT,
+                                            IdentityProvider idp) throws IdentityOAuth2Exception {
+
+        try {
+            X509Certificate x509Certificate = getCertToValidateJwt(idp);
+            String signatureAlgorithm = signedJWT.getHeader().getAlgorithm().getName();
+            validateSignatureAlgorithm(signatureAlgorithm);
+
+            PublicKey publicKey = x509Certificate.getPublicKey();
+            JWSVerifier verifier;
+            if (publicKey instanceof RSAPublicKey) {
+                verifier = new RSASSAVerifier((RSAPublicKey) publicKey);
+            } else {
+                throw new IdentityOAuth2Exception("Public key is not an RSA public key.");
+            }
+            return signedJWT.verify(verifier);
+        } catch (JOSEException | CertificateException e) {
+            throw new IdentityOAuth2Exception("Error while validating signature of jwt.", e);
+        }
+
+    }
+
+    private static void validateSignatureAlgorithm(String signatureAlgorithm) throws IdentityOAuth2Exception {
+
+        if (StringUtils.isEmpty(signatureAlgorithm)) {
+            throw new IdentityOAuth2Exception("Algorithm must not be null.");
+
+        } else {
+            if (log.isDebugEnabled()) {
+                log.debug("Signature Algorithm found in the Token Header: " + signatureAlgorithm);
+            }
+            if (!StringUtils.startsWithIgnoreCase(signatureAlgorithm, "RS")) {
+                throw new IdentityOAuth2Exception("Signature validation for algorithm: " + signatureAlgorithm
+                        + " is not supported.");
+            }
+        }
+    }
+
+    private static X509Certificate getCertToValidateJwt(IdentityProvider idp) throws IdentityOAuth2Exception,
+            CertificateException {
+
+        X509Certificate x509Certificate = (X509Certificate) IdentityApplicationManagementUtil
+                .decodeCertificate(idp.getCertificate());
+        if (x509Certificate == null) {
+            throw new IdentityOAuth2Exception("Unable to locate certificate for Identity Provider: "
+                    + idp.getDisplayName());
+        }
+        return x509Certificate;
     }
 }

--- a/system/control-plane/global/components/auth/org.wso2.vick.auth.sts.core/src/main/java/org/wso2/vick/sts/core/VickSTSConstants.java
+++ b/system/control-plane/global/components/auth/org.wso2.vick.auth.sts.core/src/main/java/org/wso2/vick/sts/core/VickSTSConstants.java
@@ -43,5 +43,6 @@ public class VickSTSConstants {
         public static final String SUBJECT = "subject";
         public static final String SCOPE = "scope";
         public static final String AUDIENCE = "audience";
+        public static final String USER_CONTEXT_JWT = "user-context-jwt";
     }
 }

--- a/system/control-plane/global/components/auth/org.wso2.vick.auth.sts.core/src/main/java/org/wso2/vick/sts/core/VickSTSRequest.java
+++ b/system/control-plane/global/components/auth/org.wso2.vick.auth.sts.core/src/main/java/org/wso2/vick/sts/core/VickSTSRequest.java
@@ -34,6 +34,8 @@ public class VickSTSRequest {
 
     private List<String> audiences;
 
+    private String userContextJwt;
+
     public String getSource() {
 
         return source;
@@ -62,5 +64,13 @@ public class VickSTSRequest {
     public void setAudiences(List<String> audiences) {
 
         this.audiences = audiences;
+    }
+
+    public String getUserContextJwt() {
+        return userContextJwt;
+    }
+
+    public void setUserContextJwt(String userContextJwt) {
+        this.userContextJwt = userContextJwt;
     }
 }

--- a/system/control-plane/global/components/auth/org.wso2.vick.auth.sts.core/src/main/java/org/wso2/vick/sts/core/VickSecureTokenService.java
+++ b/system/control-plane/global/components/auth/org.wso2.vick.auth.sts.core/src/main/java/org/wso2/vick/sts/core/VickSecureTokenService.java
@@ -17,12 +17,21 @@
  */
 package org.wso2.vick.sts.core;
 
+import com.nimbusds.jwt.SignedJWT;
+import org.apache.commons.lang.StringUtils;
+import org.wso2.carbon.identity.application.common.model.IdentityProvider;
+import org.wso2.carbon.identity.oauth2.IdentityOAuth2Exception;
+import org.wso2.carbon.idp.mgt.IdentityProviderManagementException;
 import org.wso2.vick.auth.exception.VickAuthException;
 import org.wso2.vick.auth.jwt.VickSignedJWTBuilder;
+import org.wso2.vick.auth.util.Utils;
+
+import java.text.ParseException;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * This class issues the JWT taken for the STS request in vick.
- *
  */
 public class VickSecureTokenService {
 
@@ -30,10 +39,26 @@ public class VickSecureTokenService {
 
         // TODO we need to validate stuff before issuing the token...
         try {
+            String subject = tokenRequest.getSource();
+            Map<String, Object> claims = new HashMap<>();
+
+            if (StringUtils.isNotBlank(tokenRequest.getUserContextJwt())) {
+                // TODO: add logs here.
+                // If a user context jwt is set this is a token requested to impersonate a user.
+                SignedJWT userContextJwt = SignedJWT.parse(tokenRequest.getUserContextJwt());
+                if (isUserContextJwtValid(userContextJwt)) {
+                    subject = userContextJwt.getJWTClaimsSet().getSubject();
+                    claims.putAll(Utils.getCustomClaims(userContextJwt));
+                } else {
+                    throw new VickStsException("Invalid user context JWT presented to obtain a STS token.");
+                }
+            }
+
             String jwt = new VickSignedJWTBuilder()
-                    .subject(tokenRequest.getSource())
+                    .subject(subject)
                     .scopes(tokenRequest.getScopes())
                     .audience(tokenRequest.getAudiences())
+                    .claims(claims)
                     .build();
 
             VickSTSResponse vickSTSResponse = new VickSTSResponse();
@@ -41,7 +66,21 @@ public class VickSecureTokenService {
 
             return vickSTSResponse;
         } catch (VickAuthException e) {
-            throw new VickStsException("Error issuing JWT", e);
+            throw new VickStsException("Error issuing JWT.", e);
+        } catch (ParseException e) {
+            throw new VickStsException("Error while parsing the user context JWT", e);
         }
     }
+
+    private boolean isUserContextJwtValid(SignedJWT userContextJwt) throws VickAuthException {
+        // We can't blindly trust the user context JWT present. So we do a signature verification to see if it was
+        // issued by the VICK sts
+        try {
+            IdentityProvider idp = Utils.getVickIdp();
+            return Utils.validateSignature(userContextJwt, idp);
+        } catch (IdentityProviderManagementException | IdentityOAuth2Exception e) {
+            throw new VickAuthException("Error while validating user context jwt", e);
+        }
+    }
+
 }

--- a/system/control-plane/global/components/auth/org.wso2.vick.auth.sts.core/src/main/java/org/wso2/vick/sts/core/VickStsException.java
+++ b/system/control-plane/global/components/auth/org.wso2.vick.auth.sts.core/src/main/java/org/wso2/vick/sts/core/VickStsException.java
@@ -26,4 +26,9 @@ public class VickStsException extends Exception {
 
         super(msg, e);
     }
+
+    VickStsException(String msg) {
+
+        super(msg);
+    }
 }

--- a/system/control-plane/global/components/auth/org.wso2.vick.auth.sts.endpoint/src/main/java/org/wso2/vick/auth/cell/sts/endpoint/VickStsEndpoint.java
+++ b/system/control-plane/global/components/auth/org.wso2.vick.auth.sts.endpoint/src/main/java/org/wso2/vick/auth/cell/sts/endpoint/VickStsEndpoint.java
@@ -74,6 +74,7 @@ public class VickStsEndpoint {
         stsRequest.setSource(form.getFirst(VickSTSConstants.VickSTSRequest.SUBJECT));
         stsRequest.setScopes(buildValueList(form.getFirst(VickSTSConstants.VickSTSRequest.SCOPE)));
         stsRequest.setAudiences(buildValueList(form.getFirst(VickSTSConstants.VickSTSRequest.AUDIENCE)));
+        stsRequest.setUserContextJwt(form.getFirst(VickSTSConstants.VickSTSRequest.USER_CONTEXT_JWT));
         return stsRequest;
     }
 

--- a/system/controller/artifacts/08-config.yaml
+++ b/system/controller/artifacts/08-config.yaml
@@ -41,7 +41,7 @@ data:
 
     [jwtTokenConfig]
     issuer="https://sts.vick.wso2.com"
-    audience="http://org.wso2.apimgt/gateway"
+    audience="@env:{CELL_NAME}"
     certificateAlias="wso2apim"
     trustStore.path="${ballerina.home}/bre/security/ballerinaTruststore.p12"
     trustStore.password="ballerina"


### PR DESCRIPTION
* Make the Cell Gateway audience value specific to each cell
* Support issuing JWT based on a user context JWT previously issued to a cell
* Improve Global STS JWT generator to include cell name as the audience.

**Improve Cell STS**
1. For outbound inter-cell communication obtain a JWT with the correct audience.
2. Override any authorization headers passed during intra cell communication.
3. Decouple intercepting gRPC service from Cell STS service.