### PR TITLE
Add Quick Access Links between pages

### DIFF
--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/package-lock.json
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/package-lock.json
@@ -13110,11 +13110,11 @@
       "integrity": "sha1-QzdOLiyglosO8VI0YLfXMP8i7rM="
     },
     "rimraf": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
-      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
       "requires": {
-        "glob": "^7.0.5"
+        "glob": "^7.1.3"
       }
     },
     "ripemd160": {

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/package.json
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/package.json
@@ -41,7 +41,7 @@
     "vis": "^4.21.0"
   },
   "devDependencies": {
-    "rimraf": "^2.6.2"
+    "rimraf": "^2.6.3"
   },
   "jest": {
     "resetMocks": true,

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/CellList.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/CellList.js
@@ -126,6 +126,9 @@ class CellList extends React.Component {
                 name: "Average Inbound Request Count (requests/s)"
             }
         ];
+        const options = {
+            filter: false
+        };
 
         // Processing data to find the required values
         const dataTableMap = {};
@@ -171,7 +174,7 @@ class CellList extends React.Component {
             <React.Fragment>
                 <TopToolbar title={"Cells"} onUpdate={this.loadCellInfo}/>
                 <Paper className={classes.root}>
-                    <DataTable columns={columns} data={tableData}/>
+                    <DataTable columns={columns} options={options} data={tableData}/>
                 </Paper>
             </React.Fragment>
         );

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/CellList.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/CellList.js
@@ -20,12 +20,12 @@ import HttpUtils from "../common/utils/httpUtils";
 import {Link} from "react-router-dom";
 import NotificationUtils from "../common/utils/notificationUtils";
 import Paper from "@material-ui/core/Paper";
-import PropTypes from "prop-types";
 import React from "react";
 import StateHolder from "../common/state/stateHolder";
 import TopToolbar from "../common/toptoolbar";
 import withGlobalState from "../common/state";
 import {withStyles} from "@material-ui/core/styles";
+import * as PropTypes from "prop-types";
 
 const styles = (theme) => ({
     root: {
@@ -39,9 +39,23 @@ class CellList extends React.Component {
         super(props);
 
         this.state = {
-            cellInfo: []
+            cellInfo: [],
+            isLoading: false
         };
+
+        props.globalState.addListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
     }
+
+    componentWillUnmount = () => {
+        const {globalState} = this.props;
+        globalState.removeListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
+    };
+
+    handleLoadingStateChange = (loadingStateKey, oldState, newState) => {
+        this.setState({
+            isLoading: newState.loadingOverlayCount > 0
+        });
+    };
 
     loadCellInfo = (isUserAction, queryStartTime, queryEndTime) => {
         const {globalState} = this.props;
@@ -90,7 +104,7 @@ class CellList extends React.Component {
 
     render = () => {
         const {classes, match} = this.props;
-        const {cellInfo} = this.state;
+        const {cellInfo, isLoading} = this.state;
         const columns = [
             {
                 name: "Health",
@@ -173,9 +187,15 @@ class CellList extends React.Component {
         return (
             <React.Fragment>
                 <TopToolbar title={"Cells"} onUpdate={this.loadCellInfo}/>
-                <Paper className={classes.root}>
-                    <DataTable columns={columns} options={options} data={tableData}/>
-                </Paper>
+                {
+                    isLoading
+                        ? null
+                        : (
+                            <Paper className={classes.root}>
+                                <DataTable columns={columns} options={options} data={tableData}/>
+                            </Paper>
+                        )
+                }
             </React.Fragment>
         );
     };

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/MetricsGraphs.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/MetricsGraphs.js
@@ -98,7 +98,7 @@ class MetricsGraphs extends React.Component {
     }
 
     calculateMetrics = () => {
-        const {colorGenerator, data} = this.props;
+        const {colorGenerator, data, direction} = this.props;
         const successColor = colorGenerator.getColor(ColorGenerator.SUCCESS);
         const errColor = colorGenerator.getColor(ColorGenerator.ERROR);
 
@@ -158,7 +158,7 @@ class MetricsGraphs extends React.Component {
         const trafficData = ["2xx", "3xx", "4xx", "5xx"]
             .map((datum) => ({
                 x: totalRequestsCount === 0 ? 0 : httpResponseGroupCounts[datum] * 100 / totalRequestsCount,
-                y: "Out",
+                y: direction,
                 title: (datum === "2xx" ? "OK" : datum),
                 count: httpResponseGroupCounts[datum]
             }));
@@ -660,7 +660,8 @@ MetricsGraphs.propTypes = {
         totalResponseSizeBytes: PropTypes.number.isRequired,
         totalResponseTimeMilliSec: PropTypes.number.isRequired,
         requestCount: PropTypes.number.isRequired
-    })).isRequired
+    })).isRequired,
+    direction: PropTypes.string.isRequired
 };
 
 export default withStyles(styles)(withColor(MetricsGraphs));

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/MetricsGraphs.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/MetricsGraphs.js
@@ -22,7 +22,6 @@ import CardHeader from "@material-ui/core/CardHeader";
 import Constants from "../common/constants";
 import Grid from "@material-ui/core/Grid";
 import InfoIcon from "@material-ui/icons/InfoOutlined";
-import PropTypes from "prop-types";
 import React from "react";
 import Tooltip from "@material-ui/core/Tooltip";
 import Typography from "@material-ui/core/Typography";
@@ -33,6 +32,7 @@ import {
     RadialChart, VerticalGridLines, XAxis, XYPlot, YAxis, makeWidthFlexible
 } from "react-vis";
 import withColor, {ColorGenerator} from "../common/color";
+import * as PropTypes from "prop-types";
 
 const styles = {
     root: {

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/Details.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/Details.js
@@ -58,18 +58,31 @@ class Details extends React.Component {
 
         this.state = {
             health: -1,
-            dependencyGraphData: []
+            dependencyGraphData: [],
+            isLoading: false
         };
     }
 
     componentDidMount = () => {
         const {globalState} = this.props;
 
+        globalState.addListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
         this.update(
             true,
             QueryUtils.parseTime(globalState.get(StateHolder.GLOBAL_FILTER).startTime).valueOf(),
             QueryUtils.parseTime(globalState.get(StateHolder.GLOBAL_FILTER).endTime).valueOf()
         );
+    };
+
+    componentWillUnmount = () => {
+        const {globalState} = this.props;
+        globalState.removeListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
+    };
+
+    handleLoadingStateChange = (loadingStateKey, oldState, newState) => {
+        this.setState({
+            isLoading: newState.loadingOverlayCount > 0
+        });
     };
 
     update = (isUserAction, queryStartTime, queryEndTime) => {
@@ -127,34 +140,38 @@ class Details extends React.Component {
 
     render = () => {
         const {classes} = this.props;
-        const {health} = this.state;
+        const {health, isLoading} = this.state;
 
         return (
-            <React.Fragment>
-                <Table className={classes.table}>
-                    <TableBody>
-                        <TableRow>
-                            <TableCell className={classes.tableCell}>
-                                <Typography color="textSecondary">
-                                    Health
-                                </Typography>
-                            </TableCell>
-                            <TableCell className={classes.tableCell}>
-                                <HealthIndicator value={health}/>
-                            </TableCell>
-                        </TableRow>
-                    </TableBody>
-                </Table>
-                <div className={classes.dependencies}>
-                    <Typography color="textSecondary" className={classes.subtitle}>
-                        Dependencies
-                    </Typography>
-                    <div className={classes.diagram}>
-                        {/* TODO : Implement Cell Dependency Diagram */}
-                        Dependency Diagram
-                    </div>
-                </div>
-            </React.Fragment>
+            isLoading
+                ? null
+                : (
+                    <React.Fragment>
+                        <Table className={classes.table}>
+                            <TableBody>
+                                <TableRow>
+                                    <TableCell className={classes.tableCell}>
+                                        <Typography color="textSecondary">
+                                            Health
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell className={classes.tableCell}>
+                                        <HealthIndicator value={health}/>
+                                    </TableCell>
+                                </TableRow>
+                            </TableBody>
+                        </Table>
+                        <div className={classes.dependencies}>
+                            <Typography color="textSecondary" className={classes.subtitle}>
+                                Dependencies
+                            </Typography>
+                            <div className={classes.diagram}>
+                                {/* TODO : Implement Cell Dependency Diagram */}
+                                Dependency Diagram
+                            </div>
+                        </div>
+                    </React.Fragment>
+                )
         );
     }
 

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/Details.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/Details.js
@@ -18,7 +18,6 @@ import ColorGenerator from "../../common/color/colorGenerator";
 import HealthIndicator from "../../common/HealthIndicator";
 import HttpUtils from "../../common/utils/httpUtils";
 import NotificationUtils from "../../common/utils/notificationUtils";
-import PropTypes from "prop-types";
 import QueryUtils from "../../common/utils/queryUtils";
 import React from "react";
 import StateHolder from "../../common/state/stateHolder";
@@ -30,6 +29,7 @@ import Typography from "@material-ui/core/Typography/Typography";
 import withColor from "../../common/color";
 import withGlobalState from "../../common/state";
 import {withStyles} from "@material-ui/core/styles";
+import * as PropTypes from "prop-types";
 
 const styles = (theme) => ({
     table: {

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/Metrics.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/Metrics.js
@@ -58,17 +58,31 @@ class Metrics extends React.Component {
             selectedType: Metrics.INBOUND,
             selectedCell: Metrics.ALL_VALUE,
             cells: [],
-            cellData: []
+            cellData: [],
+            isLoading: false
         };
     }
 
     componentDidMount = () => {
         const {globalState} = this.props;
+
+        globalState.addListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
         this.update(
             true,
             QueryUtils.parseTime(globalState.get(StateHolder.GLOBAL_FILTER).startTime),
             QueryUtils.parseTime(globalState.get(StateHolder.GLOBAL_FILTER).endTime)
         );
+    };
+
+    componentWillUnmount = () => {
+        const {globalState} = this.props;
+        globalState.removeListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
+    };
+
+    handleLoadingStateChange = (loadingStateKey, oldState, newState) => {
+        this.setState({
+            isLoading: newState.loadingOverlayCount > 0
+        });
     };
 
     update = (isUserAction, startTime, endTime, selectedTypeOverride, selectedCellOverride) => {
@@ -199,59 +213,63 @@ class Metrics extends React.Component {
 
     render = () => {
         const {classes} = this.props;
-        const {selectedType, selectedCell, cells, cellData, cell} = this.state;
+        const {selectedType, selectedCell, cells, cellData, cell, isLoading} = this.state;
 
         const targetSourcePrefix = selectedType === Metrics.INBOUND ? "Source" : "Target";
 
         return (
-            <React.Fragment>
-                <div className={classes.filters}>
-                    <FormControl className={classes.formControl}>
-                        <InputLabel htmlFor="selected-type">Type</InputLabel>
-                        <Select value={selectedType}
-                            onChange={this.getFilterChangeHandler("selectedType")}
-                            inputProps={{
-                                name: "selected-type",
-                                id: "selected-type"
-                            }}>
-                            <option value={Metrics.INBOUND}>Inbound</option>
-                            <option value={Metrics.OUTBOUND}>Outbound</option>
-                        </Select>
-                    </FormControl>
-                    <FormControl className={classes.formControl}>
-                        <InputLabel htmlFor="selected-cell">{targetSourcePrefix} Cell</InputLabel>
-                        <Select value={selectedCell}
-                            onChange={this.getFilterChangeHandler("selectedCell")}
-                            inputProps={{
-                                name: "selected-cell",
-                                id: "selected-cell"
-                            }}>
-                            <option value={Metrics.ALL_VALUE}>{Metrics.ALL_VALUE}</option>
-                            {
-                                cells.map((cell) => (<option key={cell} value={cell}>{cell}</option>))
-                            }
-                        </Select>
-                    </FormControl>
-                </div>
-                <div className={classes.graphs}>
-                    {
-                        cellData.length > 0
-                            ? (
-                                <MetricsGraphs data={cellData}
-                                    direction={selectedType === Metrics.INBOUND ? "In" : "Out"}/>
-                            )
-                            : (
-                                <Typography>
+            isLoading
+                ? null
+                : (
+                    <React.Fragment>
+                        <div className={classes.filters}>
+                            <FormControl className={classes.formControl}>
+                                <InputLabel htmlFor="selected-type">Type</InputLabel>
+                                <Select value={selectedType}
+                                    onChange={this.getFilterChangeHandler("selectedType")}
+                                    inputProps={{
+                                        name: "selected-type",
+                                        id: "selected-type"
+                                    }}>
+                                    <option value={Metrics.INBOUND}>Inbound</option>
+                                    <option value={Metrics.OUTBOUND}>Outbound</option>
+                                </Select>
+                            </FormControl>
+                            <FormControl className={classes.formControl}>
+                                <InputLabel htmlFor="selected-cell">{targetSourcePrefix} Cell</InputLabel>
+                                <Select value={selectedCell}
+                                    onChange={this.getFilterChangeHandler("selectedCell")}
+                                    inputProps={{
+                                        name: "selected-cell",
+                                        id: "selected-cell"
+                                    }}>
+                                    <option value={Metrics.ALL_VALUE}>{Metrics.ALL_VALUE}</option>
                                     {
-                                        selectedType === Metrics.INBOUND
-                                            ? `No Requests from the selected cell to "${cell}" cell`
-                                            : `No Requests from "${cell}" cell to the selected cell`
+                                        cells.map((cell) => (<option key={cell} value={cell}>{cell}</option>))
                                     }
-                                </Typography>
-                            )
-                    }
-                </div>
-            </React.Fragment>
+                                </Select>
+                            </FormControl>
+                        </div>
+                        <div className={classes.graphs}>
+                            {
+                                cellData.length > 0
+                                    ? (
+                                        <MetricsGraphs data={cellData}
+                                            direction={selectedType === Metrics.INBOUND ? "In" : "Out"}/>
+                                    )
+                                    : (
+                                        <Typography>
+                                            {
+                                                selectedType === Metrics.INBOUND
+                                                    ? `No Requests from the selected cell to "${cell}" cell`
+                                                    : `No Requests from "${cell}" cell to the selected cell`
+                                            }
+                                        </Typography>
+                                    )
+                            }
+                        </div>
+                    </React.Fragment>
+                )
         );
     };
 

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/Metrics.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/Metrics.js
@@ -19,7 +19,6 @@ import HttpUtils from "../../common/utils/httpUtils";
 import InputLabel from "@material-ui/core/InputLabel";
 import MetricsGraphs from "../MetricsGraphs";
 import NotificationUtils from "../../common/utils/notificationUtils";
-import PropTypes from "prop-types";
 import QueryUtils from "../../common/utils/queryUtils";
 import React from "react";
 import Select from "@material-ui/core/Select";
@@ -27,6 +26,7 @@ import StateHolder from "../../common/state/stateHolder";
 import Typography from "@material-ui/core/Typography/Typography";
 import withGlobalState from "../../common/state";
 import {withStyles} from "@material-ui/core/styles";
+import * as PropTypes from "prop-types";
 
 const styles = (theme) => ({
     filters: {

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/Metrics.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/Metrics.js
@@ -237,7 +237,8 @@ class Metrics extends React.Component {
                     {
                         cellData.length > 0
                             ? (
-                                <MetricsGraphs data={cellData}/>
+                                <MetricsGraphs data={cellData}
+                                    direction={selectedType === Metrics.INBOUND ? "In" : "Out"}/>
                             )
                             : (
                                 <Typography>

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/MicroserviceList.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/MicroserviceList.js
@@ -141,6 +141,9 @@ class MicroserviceList extends React.Component {
                 name: "Average Inbound Request Count (requests/s)"
             }
         ];
+        const options = {
+            filter: false
+        };
 
         // Processing data to find the required values
         const dataTableMap = {};
@@ -204,7 +207,7 @@ class MicroserviceList extends React.Component {
             }
         }
 
-        return <DataTable columns={columns} data={tableData}/>;
+        return <DataTable columns={columns} options={options} data={tableData}/>;
     };
 
 }

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/MicroserviceList.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/MicroserviceList.js
@@ -20,12 +20,12 @@ import HealthIndicator from "../../common/HealthIndicator";
 import HttpUtils from "../../common/utils/httpUtils";
 import {Link} from "react-router-dom";
 import NotificationUtils from "../../common/utils/notificationUtils";
-import PropTypes from "prop-types";
 import QueryUtils from "../../common/utils/queryUtils";
 import React from "react";
 import StateHolder from "../../common/state/stateHolder";
 import withGlobalState from "../../common/state";
 import {withStyles} from "@material-ui/core";
+import * as PropTypes from "prop-types";
 
 const styles = (theme) => ({
     root: {

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/MicroserviceList.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/MicroserviceList.js
@@ -39,17 +39,31 @@ class MicroserviceList extends React.Component {
         super(props);
 
         this.state = {
-            microserviceInfo: []
+            microserviceInfo: [],
+            isLoading: false
         };
     }
 
     componentDidMount = () => {
         const {globalState} = this.props;
+
+        globalState.addListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
         this.update(
             true,
             QueryUtils.parseTime(globalState.get(StateHolder.GLOBAL_FILTER).startTime),
             QueryUtils.parseTime(globalState.get(StateHolder.GLOBAL_FILTER).endTime)
         );
+    };
+
+    componentWillUnmount = () => {
+        const {globalState} = this.props;
+        globalState.removeListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
+    };
+
+    handleLoadingStateChange = (loadingStateKey, oldState, newState) => {
+        this.setState({
+            isLoading: newState.loadingOverlayCount > 0
+        });
     };
 
     update = (isUserAction, startTime, endTime) => {
@@ -105,7 +119,7 @@ class MicroserviceList extends React.Component {
 
     render = () => {
         const {cell} = this.props;
-        const {microserviceInfo} = this.state;
+        const {microserviceInfo, isLoading} = this.state;
         const columns = [
             {
                 name: "Health",
@@ -207,7 +221,11 @@ class MicroserviceList extends React.Component {
             }
         }
 
-        return <DataTable columns={columns} options={options} data={tableData}/>;
+        return (
+            isLoading
+                ? null
+                : <DataTable columns={columns} options={options} data={tableData}/>
+        );
     };
 
 }

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/MicroserviceList.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/MicroserviceList.js
@@ -20,7 +20,6 @@ import HealthIndicator from "../../common/HealthIndicator";
 import HttpUtils from "../../common/utils/httpUtils";
 import {Link} from "react-router-dom";
 import NotificationUtils from "../../common/utils/notificationUtils";
-import Paper from "@material-ui/core/Paper/Paper";
 import PropTypes from "prop-types";
 import QueryUtils from "../../common/utils/queryUtils";
 import React from "react";
@@ -105,7 +104,7 @@ class MicroserviceList extends React.Component {
     };
 
     render = () => {
-        const {classes, cell} = this.props;
+        const {cell} = this.props;
         const {microserviceInfo} = this.state;
         const columns = [
             {
@@ -205,11 +204,7 @@ class MicroserviceList extends React.Component {
             }
         }
 
-        return (
-            <Paper className={classes.root}>
-                <DataTable columns={columns} data={tableData}/>
-            </Paper>
-        );
+        return <DataTable columns={columns} data={tableData}/>;
     };
 
 }

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/index.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/index.js
@@ -14,20 +14,23 @@
  * limitations under the License.
  */
 
+import Button from "@material-ui/core/Button/Button";
 import Details from "./Details";
 import Grey from "@material-ui/core/colors/grey";
 import HttpUtils from "../../common/utils/httpUtils";
+import {Link} from "react-router-dom";
 import Metrics from "./Metrics";
 import MicroserviceList from "./MicroserviceList";
 import Paper from "@material-ui/core/Paper/Paper";
-import PropTypes from "prop-types";
 import React from "react";
 import StateHolder from "../../common/state/stateHolder";
 import Tab from "@material-ui/core/Tab";
 import Tabs from "@material-ui/core/Tabs";
+import Timeline from "@material-ui/icons/Timeline";
 import TopToolbar from "../../common/toptoolbar";
 import withGlobalState from "../../common/state";
 import {withStyles} from "@material-ui/core/styles";
+import * as PropTypes from "prop-types";
 
 const styles = (theme) => ({
     root: {
@@ -42,6 +45,15 @@ const styles = (theme) => ({
         borderBottomWidth: 1,
         borderBottomStyle: "solid",
         borderBottomColor: Grey[200]
+    },
+    tabBar: {
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        ...theme.mixins.toolbar
+    },
+    viewTracesContent: {
+        paddingLeft: theme.spacing.unit
     }
 });
 
@@ -97,16 +109,25 @@ class Cell extends React.Component {
         const tabContent = [Details, MicroserviceList, Metrics];
         const SelectedTabContent = tabContent[selectedTabIndex];
 
+        const traceSearch = {
+            cell: cellName
+        };
         return (
             <React.Fragment>
                 <TopToolbar title={`${cellName}`} subTitle="(Cell)" onUpdate={this.handleOnUpdate}/>
                 <Paper className={classes.root}>
-                    <Tabs value={selectedTabIndex} indicatorColor="primary"
-                        onChange={this.handleTabChange} className={classes.tabs}>
-                        <Tab label="Details"/>
-                        <Tab label="Microservices"/>
-                        <Tab label="Metrics"/>
-                    </Tabs>
+                    <div className={classes.tabBar}>
+                        <Tabs value={selectedTabIndex} indicatorColor="primary"
+                            onChange={this.handleTabChange} className={classes.tabs}>
+                            <Tab label="Details"/>
+                            <Tab label="Microservices"/>
+                            <Tab label="Metrics"/>
+                        </Tabs>
+                        <Button className={classes.button} component={Link}
+                            to={`/tracing/search${HttpUtils.generateQueryParamString(traceSearch)}`}>
+                            <Timeline/><span className={classes.viewTracesContent}>View Traces</span>
+                        </Button>
+                    </div>
                     <SelectedTabContent innerRef={this.tabContentRef} cell={cellName}/>
                 </Paper>
             </React.Fragment>

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/index.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/cell/index.js
@@ -23,12 +23,10 @@ import Metrics from "./Metrics";
 import MicroserviceList from "./MicroserviceList";
 import Paper from "@material-ui/core/Paper/Paper";
 import React from "react";
-import StateHolder from "../../common/state/stateHolder";
 import Tab from "@material-ui/core/Tab";
 import Tabs from "@material-ui/core/Tabs";
 import Timeline from "@material-ui/icons/Timeline";
 import TopToolbar from "../../common/toptoolbar";
-import withGlobalState from "../../common/state";
 import {withStyles} from "@material-ui/core/styles";
 import * as PropTypes from "prop-types";
 
@@ -148,8 +146,7 @@ Cell.propTypes = {
     }),
     location: PropTypes.shape({
         search: PropTypes.string.isRequired
-    }).isRequired,
-    globalState: PropTypes.instanceOf(StateHolder).isRequired
+    }).isRequired
 };
 
-export default withStyles(styles)(withGlobalState(Cell));
+export default withStyles(styles)(Cell);

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/index.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/index.js
@@ -20,9 +20,9 @@ import Cell from "./cell";
 import CellList from "./CellList";
 import MicroService from "./microservice";
 import NotFound from "../common/error/NotFound";
-import PropTypes from "prop-types";
 import React from "react";
 import {Route, Switch, withRouter} from "react-router-dom";
+import * as PropTypes from "prop-types";
 
 const Cells = ({match}) => (
     <Switch>

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/microservice/Details.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/microservice/Details.js
@@ -18,7 +18,6 @@ import HealthIndicator from "../../common/HealthIndicator";
 import HttpUtils from "../../common/utils/httpUtils";
 import {Link} from "react-router-dom";
 import NotificationUtils from "../../common/utils/notificationUtils";
-import PropTypes from "prop-types";
 import QueryUtils from "../../common/utils/queryUtils";
 import React from "react";
 import StateHolder from "../../common/state/stateHolder";
@@ -29,6 +28,7 @@ import TableRow from "@material-ui/core/TableRow";
 import Typography from "@material-ui/core/Typography/Typography";
 import withGlobalState from "../../common/state";
 import {withStyles} from "@material-ui/core/styles";
+import * as PropTypes from "prop-types";
 
 const styles = (theme) => ({
     table: {

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/microservice/Details.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/microservice/Details.js
@@ -57,18 +57,31 @@ class Details extends React.Component {
 
         this.state = {
             health: -1,
-            dependencyGraphData: []
+            dependencyGraphData: [],
+            isLoading: false
         };
     }
 
     componentDidMount = () => {
         const {globalState} = this.props;
 
+        globalState.addListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
         this.update(
             true,
             QueryUtils.parseTime(globalState.get(StateHolder.GLOBAL_FILTER).startTime).valueOf(),
             QueryUtils.parseTime(globalState.get(StateHolder.GLOBAL_FILTER).endTime).valueOf()
         );
+    };
+
+    componentWillUnmount = () => {
+        const {globalState} = this.props;
+        globalState.removeListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
+    };
+
+    handleLoadingStateChange = (loadingStateKey, oldState, newState) => {
+        this.setState({
+            isLoading: newState.loadingOverlayCount > 0
+        });
     };
 
     update = (isUserAction, queryStartTime, queryEndTime) => {
@@ -127,42 +140,46 @@ class Details extends React.Component {
 
     render() {
         const {classes, cell} = this.props;
-        const {health} = this.state;
+        const {health, isLoading} = this.state;
         return (
-            <React.Fragment>
-                <Table className={classes.table}>
-                    <TableBody>
-                        <TableRow>
-                            <TableCell className={classes.tableCell}>
-                                <Typography color="textSecondary">
-                                    Health
-                                </Typography>
-                            </TableCell>
-                            <TableCell className={classes.tableCell}>
-                                <HealthIndicator value={health}/>
-                            </TableCell>
-                        </TableRow>
-                        <TableRow>
-                            <TableCell className={classes.tableCell}>
-                                <Typography color="textSecondary">
-                                    Cell
-                                </Typography>
-                            </TableCell>
-                            <TableCell className={classes.tableCell}>
-                                <Link to={`/cells/${cell}`}>{cell}</Link>
-                            </TableCell>
-                        </TableRow>
-                    </TableBody>
-                </Table>
-                <div className={classes.dependencies}>
-                    <Typography color="textSecondary" className={classes.subtitle}>
-                        Dependencies
-                    </Typography>
-                    <div className={classes.diagram}>
-                        Dependency Diagram
-                    </div>
-                </div>
-            </React.Fragment>
+            isLoading
+                ? null
+                : (
+                    <React.Fragment>
+                        <Table className={classes.table}>
+                            <TableBody>
+                                <TableRow>
+                                    <TableCell className={classes.tableCell}>
+                                        <Typography color="textSecondary">
+                                            Health
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell className={classes.tableCell}>
+                                        <HealthIndicator value={health}/>
+                                    </TableCell>
+                                </TableRow>
+                                <TableRow>
+                                    <TableCell className={classes.tableCell}>
+                                        <Typography color="textSecondary">
+                                            Cell
+                                        </Typography>
+                                    </TableCell>
+                                    <TableCell className={classes.tableCell}>
+                                        <Link to={`/cells/${cell}`}>{cell}</Link>
+                                    </TableCell>
+                                </TableRow>
+                            </TableBody>
+                        </Table>
+                        <div className={classes.dependencies}>
+                            <Typography color="textSecondary" className={classes.subtitle}>
+                                Dependencies
+                            </Typography>
+                            <div className={classes.diagram}>
+                                Dependency Diagram
+                            </div>
+                        </div>
+                    </React.Fragment>
+                )
         );
     }
 

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/microservice/K8sObjects.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/microservice/K8sObjects.js
@@ -20,15 +20,17 @@ import BarChartIcon from "@material-ui/icons/BarChart";
 import Green from "@material-ui/core/colors/green";
 import IconButton from "@material-ui/core/IconButton";
 import {Link} from "react-router-dom";
-import PropTypes from "prop-types";
 import React from "react";
+import StateHolder from "../../common/state/stateHolder";
 import Table from "@material-ui/core/Table";
 import TableBody from "@material-ui/core/TableBody";
 import TableCell from "@material-ui/core/TableCell";
 import TableHead from "@material-ui/core/TableHead";
 import TableRow from "@material-ui/core/TableRow";
 import Typography from "@material-ui/core/Typography/Typography";
+import withGlobalState from "../../common/state";
 import {withStyles} from "@material-ui/core/styles";
+import * as PropTypes from "prop-types";
 
 const styles = (theme) => ({
     container: {
@@ -56,85 +58,116 @@ const styles = (theme) => ({
     }
 });
 
-const K8sObjects = (props) => (
-    <React.Fragment>
-        <div className={props.classes.container}>
-            <Typography color="inherit" className={props.classes.subtitle}>
-                Service
-            </Typography>
-            <Table className={props.classes.table}>
-                <TableHead>
-                    <TableRow>
-                        <TableCell>Service</TableCell>
-                        <TableCell>Type</TableCell>
-                        <TableCell className={props.classes.cellWidth20}>Creation Time</TableCell>
-                        <TableCell className={props.classes.cellWidth20}>Age</TableCell>
-                        <TableCell className={props.classes.cellWidth10}/>
-                    </TableRow>
-                </TableHead>
-                <TableBody>
-                    <TableRow key="">
-                        <TableCell className={props.classes.tableCell} component="th" scope="row"/>
-                        <TableCell className={props.classes.tableCell}/>
-                        <TableCell className={props.classes.tableCell}/>
-                        <TableCell className={props.classes.tableCell}/>
-                        <TableCell className={props.classes.tableCell}/>
-                    </TableRow>
-                </TableBody>
-            </Table>
-            <Typography color="inherit" className={props.classes.subtitle}>
-                Workload
-            </Typography>
-            <Table className={props.classes.table}>
-                <TableHead>
-                    <TableRow>
-                        <TableCell>Workload</TableCell>
-                        <TableCell className={props.classes.cellWidth20}>Creation Time</TableCell>
-                        <TableCell className={props.classes.cellWidth20}>Age</TableCell>
-                        <TableCell className={props.classes.cellWidth10}/>
-                    </TableRow>
-                </TableHead>
-                <TableBody>
-                    <TableRow key="">
-                        <TableCell className={props.classes.tableCell} component="th" scope="row"/>
-                        <TableCell className={props.classes.tableCell}/>
-                        <TableCell className={props.classes.tableCell}/>
-                        <TableCell className={props.classes.tableCell}/>
-                    </TableRow>
-                </TableBody>
-            </Table>
-            <Typography color="inherit" className={props.classes.subtitle}>
-                Pods
-            </Typography>
-            <Table className={props.classes.table}>
-                <TableHead>
-                    <TableRow>
-                        <TableCell>Pod</TableCell>
-                        <TableCell>Restarts</TableCell>
-                        <TableCell className={props.classes.cellWidth20}>Age</TableCell>
-                        <TableCell>Metrics</TableCell>
-                    </TableRow>
-                </TableHead>
-                <TableBody>
-                    <TableRow key="">
-                        <TableCell component="th" scope="row"/>
-                        <TableCell className={props.classes.cellWidth20}/>
-                        <TableCell className={props.classes.cellWidth20}/>
-                        <TableCell className={props.classes.cellWidth10}>
-                            <IconButton className={props.classes.button} size="small" color="inherit" component={Link}
-                                to="/system-metrics/pod-usage">
-                                <BarChartIcon/>
-                            </IconButton>
-                        </TableCell>
-                    </TableRow>
-                </TableBody>
-            </Table>
-        </div>
-    </React.Fragment>
-);
+class K8sObjects extends React.Component {
+
+    constructor(props) {
+        super(props);
+
+        this.state = {
+            isLoading: false
+        };
+    }
+
+    componentDidMount = () => {
+        const {globalState} = this.props;
+        globalState.addListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
+    };
+
+    componentWillUnmount = () => {
+        const {globalState} = this.props;
+        globalState.removeListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
+    };
+
+    handleLoadingStateChange = (loadingStateKey, oldState, newState) => {
+        this.setState({
+            isLoading: newState.loadingOverlayCount > 0
+        });
+    };
+
+    render = () => {
+        const {classes} = this.props;
+        const {isLoading} = this.state;
+        return (
+            isLoading
+                ? null
+                : (
+                    <React.Fragment>
+                        <div className={classes.container}>
+                            <Typography color="inherit" className={classes.subtitle}>Service</Typography>
+                            <Table className={classes.table}>
+                                <TableHead>
+                                    <TableRow>
+                                        <TableCell>Service</TableCell>
+                                        <TableCell>Type</TableCell>
+                                        <TableCell className={classes.cellWidth20}>Creation Time</TableCell>
+                                        <TableCell className={classes.cellWidth20}>Age</TableCell>
+                                        <TableCell className={classes.cellWidth10}/>
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    <TableRow key="">
+                                        <TableCell className={classes.tableCell} component="th" scope="row"/>
+                                        <TableCell className={classes.tableCell}/>
+                                        <TableCell className={classes.tableCell}/>
+                                        <TableCell className={classes.tableCell}/>
+                                        <TableCell className={classes.tableCell}/>
+                                    </TableRow>
+                                </TableBody>
+                            </Table>
+                            <Typography color="inherit" className={classes.subtitle}>Workload</Typography>
+                            <Table className={classes.table}>
+                                <TableHead>
+                                    <TableRow>
+                                        <TableCell>Workload</TableCell>
+                                        <TableCell className={classes.cellWidth20}>Creation Time</TableCell>
+                                        <TableCell className={classes.cellWidth20}>Age</TableCell>
+                                        <TableCell className={classes.cellWidth10}/>
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    <TableRow key="">
+                                        <TableCell className={classes.tableCell} component="th" scope="row"/>
+                                        <TableCell className={classes.tableCell}/>
+                                        <TableCell className={classes.tableCell}/>
+                                        <TableCell className={classes.tableCell}/>
+                                    </TableRow>
+                                </TableBody>
+                            </Table>
+                            <Typography color="inherit" className={classes.subtitle}>Pods</Typography>
+                            <Table className={classes.table}>
+                                <TableHead>
+                                    <TableRow>
+                                        <TableCell>Pod</TableCell>
+                                        <TableCell>Restarts</TableCell>
+                                        <TableCell className={classes.cellWidth20}>Age</TableCell>
+                                        <TableCell>Metrics</TableCell>
+                                    </TableRow>
+                                </TableHead>
+                                <TableBody>
+                                    <TableRow key="">
+                                        <TableCell component="th" scope="row"/>
+                                        <TableCell className={classes.cellWidth20}/>
+                                        <TableCell className={classes.cellWidth20}/>
+                                        <TableCell className={classes.cellWidth10}>
+                                            <IconButton className={classes.button} size="small" color="inherit"
+                                                component={Link} to="/system-metrics/pod-usage">
+                                                <BarChartIcon/>
+                                            </IconButton>
+                                        </TableCell>
+                                    </TableRow>
+                                </TableBody>
+                            </Table>
+                        </div>
+                    </React.Fragment>
+                )
+        );
+    }
+
+}
 
 K8sObjects.propTypes = {
-    classes: PropTypes.object.isRequired
+    classes: PropTypes.object.isRequired,
+    globalState: PropTypes.instanceOf(StateHolder).isRequired
 };
 
-export default withStyles(styles)(K8sObjects);
+export default withStyles(styles)(withGlobalState(K8sObjects));

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/microservice/Metrics.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/microservice/Metrics.js
@@ -310,7 +310,8 @@ class Metrics extends React.Component {
                     {
                         microserviceData.length > 0
                             ? (
-                                <MetricsGraphs data={microserviceData}/>
+                                <MetricsGraphs data={microserviceData}
+                                    direction={selectedType === Metrics.INBOUND ? "In" : "Out"}/>
                             )
                             : (
                                 <Typography>

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/microservice/Metrics.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/microservice/Metrics.js
@@ -19,7 +19,6 @@ import HttpUtils from "../../common/utils/httpUtils";
 import InputLabel from "@material-ui/core/InputLabel";
 import MetricsGraphs from "../MetricsGraphs";
 import NotificationUtils from "../../common/utils/notificationUtils";
-import PropTypes from "prop-types";
 import QueryUtils from "../../common/utils/queryUtils";
 import React from "react";
 import Select from "@material-ui/core/Select";
@@ -27,6 +26,7 @@ import StateHolder from "../../common/state/stateHolder";
 import Typography from "@material-ui/core/Typography/Typography";
 import withGlobalState from "../../common/state";
 import {withStyles} from "@material-ui/core/styles";
+import * as PropTypes from "prop-types";
 
 const styles = (theme) => ({
     filters: {
@@ -63,17 +63,31 @@ class Metrics extends React.Component {
                 availableCells: [],
                 availableMicroservices: [] // Filtered based on the selected cell
             },
-            microserviceData: []
+            microserviceData: [],
+            isLoading: false
         };
     }
 
     componentDidMount = () => {
         const {globalState} = this.props;
+
+        globalState.addListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
         this.update(
             true,
             QueryUtils.parseTime(globalState.get(StateHolder.GLOBAL_FILTER).startTime),
             QueryUtils.parseTime(globalState.get(StateHolder.GLOBAL_FILTER).endTime)
         );
+    };
+
+    componentWillUnmount = () => {
+        const {globalState} = this.props;
+        globalState.removeListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
+    };
+
+    handleLoadingStateChange = (loadingStateKey, oldState, newState) => {
+        this.setState({
+            isLoading: newState.loadingOverlayCount > 0
+        });
     };
 
     update = (isUserAction, startTime, endTime, selectedTypeOverride, selectedCellOverride,
@@ -256,77 +270,84 @@ class Metrics extends React.Component {
 
     render = () => {
         const {classes, cell, microservice} = this.props;
-        const {selectedType, selectedCell, selectedMicroservice, microserviceData, metadata} = this.state;
+        const {selectedType, selectedCell, selectedMicroservice, microserviceData, metadata, isLoading} = this.state;
 
         const targetSourcePrefix = selectedType === Metrics.INBOUND ? "Source" : "Target";
 
         return (
-            <React.Fragment>
-                <div className={classes.filters}>
-                    <FormControl className={classes.formControl}>
-                        <InputLabel htmlFor="selected-type">Type</InputLabel>
-                        <Select value={selectedType}
-                            onChange={this.getFilterChangeHandler("selectedType")}
-                            inputProps={{
-                                name: "selected-type",
-                                id: "selected-type"
-                            }}>
-                            <option value={Metrics.INBOUND}>{Metrics.INBOUND}</option>
-                            <option value={Metrics.OUTBOUND}>{Metrics.OUTBOUND}</option>
-                        </Select>
-                    </FormControl>
-                    <FormControl className={classes.formControl}>
-                        <InputLabel htmlFor="selected-cell">{targetSourcePrefix} Cell</InputLabel>
-                        <Select value={selectedCell}
-                            onChange={this.getFilterChangeHandler("selectedCell")}
-                            inputProps={{
-                                name: "selected-cell",
-                                id: "selected-cell"
-                            }}>
-                            <option value={Metrics.ALL_VALUE}>{Metrics.ALL_VALUE}</option>
-                            {
-                                metadata.availableCells.map((cell) => (<option key={cell} value={cell}>{cell}</option>))
-                            }
-                        </Select>
-                    </FormControl>
-                    <FormControl className={classes.formControl}>
-                        <InputLabel htmlFor="selected-microservice">{targetSourcePrefix} Microservice</InputLabel>
-                        <Select value={selectedMicroservice}
-                            onChange={this.getFilterChangeHandler("selectedMicroservice")}
-                            inputProps={{
-                                name: "selected-microservice",
-                                id: "selected-microservice"
-                            }}>
-                            <option value={Metrics.ALL_VALUE}>{Metrics.ALL_VALUE}</option>
-                            {
-                                metadata.availableMicroservices.map((microservice) => (
-                                    <option key={microservice} value={microservice}>{microservice}</option>
-                                ))
-                            }
-                        </Select>
-                    </FormControl>
-                </div>
-                <div className={classes.graphs}>
-                    {
-                        microserviceData.length > 0
-                            ? (
-                                <MetricsGraphs data={microserviceData}
-                                    direction={selectedType === Metrics.INBOUND ? "In" : "Out"}/>
-                            )
-                            : (
-                                <Typography>
+            isLoading
+                ? null
+                : (
+                    <React.Fragment>
+                        <div className={classes.filters}>
+                            <FormControl className={classes.formControl}>
+                                <InputLabel htmlFor="selected-type">Type</InputLabel>
+                                <Select value={selectedType}
+                                    onChange={this.getFilterChangeHandler("selectedType")}
+                                    inputProps={{
+                                        name: "selected-type",
+                                        id: "selected-type"
+                                    }}>
+                                    <option value={Metrics.INBOUND}>{Metrics.INBOUND}</option>
+                                    <option value={Metrics.OUTBOUND}>{Metrics.OUTBOUND}</option>
+                                </Select>
+                            </FormControl>
+                            <FormControl className={classes.formControl}>
+                                <InputLabel htmlFor="selected-cell">{targetSourcePrefix} Cell</InputLabel>
+                                <Select value={selectedCell}
+                                    onChange={this.getFilterChangeHandler("selectedCell")}
+                                    inputProps={{
+                                        name: "selected-cell",
+                                        id: "selected-cell"
+                                    }}>
+                                    <option value={Metrics.ALL_VALUE}>{Metrics.ALL_VALUE}</option>
                                     {
-                                        selectedType === Metrics.INBOUND
-                                            ? "No Requests from the selected microservice "
-                                                + `to the "${cell}" cell's "${microservice}" microservice`
-                                            : `No Requests from the "${cell}" cell's "${microservice}" microservice `
-                                                + "to the selected microservice"
+                                        metadata.availableCells.map(
+                                            (cell) => (<option key={cell} value={cell}>{cell}</option>))
                                     }
-                                </Typography>
-                            )
-                    }
-                </div>
-            </React.Fragment>
+                                </Select>
+                            </FormControl>
+                            <FormControl className={classes.formControl}>
+                                <InputLabel htmlFor="selected-microservice">
+                                    {targetSourcePrefix} Microservice
+                                </InputLabel>
+                                <Select value={selectedMicroservice}
+                                    onChange={this.getFilterChangeHandler("selectedMicroservice")}
+                                    inputProps={{
+                                        name: "selected-microservice",
+                                        id: "selected-microservice"
+                                    }}>
+                                    <option value={Metrics.ALL_VALUE}>{Metrics.ALL_VALUE}</option>
+                                    {
+                                        metadata.availableMicroservices.map((microservice) => (
+                                            <option key={microservice} value={microservice}>{microservice}</option>
+                                        ))
+                                    }
+                                </Select>
+                            </FormControl>
+                        </div>
+                        <div className={classes.graphs}>
+                            {
+                                microserviceData.length > 0
+                                    ? (
+                                        <MetricsGraphs data={microserviceData}
+                                            direction={selectedType === Metrics.INBOUND ? "In" : "Out"}/>
+                                    )
+                                    : (
+                                        <Typography>
+                                            {
+                                                selectedType === Metrics.INBOUND
+                                                    ? "No Requests from the selected microservice "
+                                                        + `to the "${cell}" cell's "${microservice}" microservice`
+                                                    : `No Requests from the "${cell}" cell's "${microservice}" `
+                                                        + "microservice to the selected microservice"
+                                            }
+                                        </Typography>
+                                    )
+                            }
+                        </div>
+                    </React.Fragment>
+                )
         );
     };
 

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/microservice/index.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/cells/microservice/index.js
@@ -14,18 +14,21 @@
  * limitations under the License.
  */
 
+import Button from "@material-ui/core/Button/Button";
 import Details from "./Details";
 import Grey from "@material-ui/core/colors/grey";
 import HttpUtils from "../../common/utils/httpUtils";
 import K8sObjects from "./K8sObjects";
+import {Link} from "react-router-dom";
 import Metrics from "./Metrics";
 import Paper from "@material-ui/core/Paper";
-import PropTypes from "prop-types";
 import React from "react";
 import Tab from "@material-ui/core/Tab";
 import Tabs from "@material-ui/core/Tabs";
+import Timeline from "@material-ui/icons/Timeline";
 import TopToolbar from "../../common/toptoolbar";
 import {withStyles} from "@material-ui/core/styles";
+import * as PropTypes from "prop-types";
 
 const styles = (theme) => ({
     root: {
@@ -40,6 +43,15 @@ const styles = (theme) => ({
         borderBottomWidth: 1,
         borderBottomStyle: "solid",
         borderBottomColor: Grey[200]
+    },
+    tabBar: {
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "space-between",
+        ...theme.mixins.toolbar
+    },
+    viewTracesContent: {
+        paddingLeft: theme.spacing.unit
     }
 });
 
@@ -95,16 +107,26 @@ class Microservice extends React.Component {
         const tabContent = [Details, K8sObjects, Metrics];
         const SelectedTabContent = tabContent[selectedTabIndex];
 
+        const traceSearch = {
+            cell: cellName,
+            microservice: microserviceName
+        };
         return (
             <React.Fragment>
                 <TopToolbar title={`${microserviceName}`} subTitle="(Microservice)" onUpdate={this.handleOnUpdate}/>
                 <Paper className={classes.root}>
-                    <Tabs value={selectedTabIndex} indicatorColor="primary"
-                        onChange={this.handleTabChange} className={classes.tabs}>
-                        <Tab label="Details"/>
-                        <Tab label="K8s Objects"/>
-                        <Tab label="Metrics"/>
-                    </Tabs>
+                    <div className={classes.tabBar}>
+                        <Tabs value={selectedTabIndex} indicatorColor="primary"
+                            onChange={this.handleTabChange} className={classes.tabs}>
+                            <Tab label="Details"/>
+                            <Tab label="K8s Objects"/>
+                            <Tab label="Metrics"/>
+                        </Tabs>
+                        <Button className={classes.button} component={Link}
+                            to={`/tracing/search${HttpUtils.generateQueryParamString(traceSearch)}`}>
+                            <Timeline/><span className={classes.viewTracesContent}>View Traces</span>
+                        </Button>
+                    </div>
                     <SelectedTabContent innerRef={this.tabContentRef} cell={cellName} microservice={microserviceName}/>
                 </Paper>
             </React.Fragment>

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/common/DataTable.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/common/DataTable.js
@@ -33,8 +33,8 @@ const styles = (theme) => ({
 });
 
 const DataTable = (props) => {
-    const {classes} = props;
-    const options = {
+    const {classes, options, columns, data} = props;
+    const defaultOptions = {
         download: false,
         selectableRows: false,
         print: false,
@@ -44,15 +44,14 @@ const DataTable = (props) => {
 
     return (
         <div className={classes.tableWrapper}>
-            <MUIDataTable data={props.data} columns={props.columns} options={options}/>
+            <MUIDataTable data={data} columns={columns} options={{...defaultOptions, ...options}}/>
         </div>
     );
 };
 
 DataTable.propTypes = {
-    data: PropTypes.arrayOf(PropTypes.arrayOf(
-        PropTypes.any
-    )).isRequired,
+    data: PropTypes.arrayOf(PropTypes.arrayOf(PropTypes.any)).isRequired,
+    options: PropTypes.object.isRequired,
     columns: PropTypes.arrayOf(PropTypes.any).isRequired,
     classes: PropTypes.object.isRequired
 };

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/common/toptoolbar/DateRangePicker.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/common/toptoolbar/DateRangePicker.js
@@ -248,7 +248,7 @@ class DateRangePicker extends React.Component {
                             </Grid>
                         </Grid>
                         <Grid container>
-                            <Grid item xs={2}></Grid>
+                            <Grid item xs={2}/>
                             <Grid item xs={10}>
                                 <Button variant="outlined" size="small" color="primary"
                                     disabled={Boolean(fromErrorMessage || toErrorMessage)}

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/common/toptoolbar/index.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/common/toptoolbar/index.js
@@ -23,7 +23,6 @@ import IconButton from "@material-ui/core/IconButton/IconButton";
 import InputAdornment from "@material-ui/core/InputAdornment/InputAdornment";
 import MenuItem from "@material-ui/core/MenuItem/MenuItem";
 import Popover from "@material-ui/core/Popover";
-import PropTypes from "prop-types";
 import QueryUtils from "../utils/queryUtils";
 import React from "react";
 import Refresh from "@material-ui/icons/Refresh";
@@ -33,6 +32,7 @@ import Typography from "@material-ui/core/Typography/Typography";
 import {withRouter} from "react-router-dom";
 import {withStyles} from "@material-ui/core";
 import withGlobalState, {StateHolder} from "../state";
+import * as PropTypes from "prop-types";
 
 const styles = (theme) => ({
     container: {

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/common/utils/httpUtils.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/common/utils/httpUtils.js
@@ -68,7 +68,8 @@ class HttpUtils {
                 // Validating
                 if (typeof queryParamValue !== "string" && typeof queryParamValue !== "number"
                     && typeof queryParamValue !== "boolean") {
-                    throw Error(`Query param value need to be a string, instead found ${typeof queryParamValue}`);
+                    throw Error("Query param value need to be a string, number or boolean "
+                        + `instead found ${typeof queryParamValue}`);
                 }
 
                 // Generating query string

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/common/utils/notificationUtils.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/common/utils/notificationUtils.js
@@ -53,14 +53,6 @@ class NotificationUtils {
     };
 
     /**
-     * Check if the loading overlay is currently shown.
-     *
-     * @param {StateHolder} globalState The global state provided to the current component
-     * @returns {boolean} True if the loading state is currently shown
-     */
-    static isLoadingOverlayShown = (globalState) => globalState.get(StateHolder.LOADING_STATE).loadingOverlayCount > 0;
-
-    /**
      * Show a notification to the user.
      *
      * @param {string} message The message to be shown in the notification

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/common/utils/notificationUtils.test.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/common/utils/notificationUtils.test.js
@@ -1,4 +1,3 @@
-
 /*
  * Copyright (c) 2018, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
  *
@@ -90,26 +89,6 @@ describe("NotificationUtils", () => {
             const loadingState = state.get(StateHolder.LOADING_STATE);
             expect(loadingState.loadingOverlayCount).toBe(213);
             expect(loadingState.message).toBeNull();
-        });
-    });
-
-    describe("isLoadingOverlayShown()", () => {
-        it("should return true if the overlay is currently shown", () => {
-            state.set(StateHolder.LOADING_STATE, {
-                loadingOverlayCount: 3,
-                message: "Initial Test Message 3"
-            });
-
-            expect(NotificationUtils.isLoadingOverlayShown(state)).toBe(true);
-        });
-
-        it("should return false if the overlay is currently not shown", () => {
-            state.set(StateHolder.LOADING_STATE, {
-                loadingOverlayCount: 0,
-                message: 0
-            });
-
-            expect(NotificationUtils.isLoadingOverlayShown(state)).toBe(false);
         });
     });
 

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/DependencyGraph.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/DependencyGraph.js
@@ -23,10 +23,57 @@ import * as PropTypes from "prop-types";
 
 class DependencyGraph extends React.Component {
 
+    static DEFAULT_GRAPH_CONFIG = {
+        directed: true,
+        automaticRearrangeAfterDropNode: false,
+        collapsible: false,
+        highlightDegree: 1,
+        highlightOpacity: 0.2,
+        linkHighlightBehavior: false,
+        maxZoom: 8,
+        minZoom: 0.1,
+        nodeHighlightBehavior: true,
+        panAndZoom: false,
+        staticGraph: false,
+        height: 700,
+        width: 1050,
+        d3: {
+            alphaTarget: 0.05,
+            gravity: -1500,
+            linkLength: 150,
+            linkStrength: 1
+        },
+        node: {
+            color: "#d3d3d3",
+            fontColor: "black",
+            fontSize: 18,
+            fontWeight: "normal",
+            highlightColor: "red",
+            highlightFontSize: 18,
+            highlightFontWeight: "bold",
+            highlightStrokeColor: "SAME",
+            highlightStrokeWidth: 1.5,
+            labelProperty: "name",
+            mouseCursor: "pointer",
+            opacity: 1,
+            renderLabel: true,
+            size: 600,
+            strokeColor: "green",
+            strokeWidth: 2
+        },
+        link: {
+            color: "#d3d3d3",
+            opacity: 1,
+            semanticStrokeWidth: false,
+            strokeWidth: 4,
+            highlightColor: "black"
+        }
+    };
+
     shouldComponentUpdate = (nextProps) => nextProps.reloadGraph;
 
     render = () => {
-        const {data, ...otherProps} = this.props;
+        const {data, config, ...otherProps} = this.props;
 
         // Finding distinct links
         const links = [];
@@ -47,7 +94,22 @@ class DependencyGraph extends React.Component {
         if (data.nodes && data.nodes.length > 0) {
             view = (
                 <ErrorBoundary title={"Unable to Render"} description={"Unable to Render due to Invalid Data"}>
-                    <Graph {...otherProps} data={{...data, links: links}}/>
+                    <Graph {...otherProps} data={{...data, links: links}} config={{
+                        ...DependencyGraph.DEFAULT_GRAPH_CONFIG,
+                        ...config,
+                        d3: {
+                            ...DependencyGraph.DEFAULT_GRAPH_CONFIG.d3,
+                            ...config.d3
+                        },
+                        node: {
+                            ...DependencyGraph.DEFAULT_GRAPH_CONFIG.node,
+                            ...config.node
+                        },
+                        link: {
+                            ...DependencyGraph.DEFAULT_GRAPH_CONFIG.link,
+                            ...config.link
+                        }
+                    }}/>
                 </ErrorBoundary>
             );
         } else {

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/DependencyGraph.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/DependencyGraph.js
@@ -16,52 +16,50 @@
  * under the License.
  */
 
+import ErrorBoundary from "../common/error/ErrorBoundary";
 import {Graph} from "react-d3-graph";
-import PropTypes from "prop-types";
 import React from "react";
-
+import * as PropTypes from "prop-types";
 
 class DependencyGraph extends React.Component {
 
-    shouldComponentUpdate = (nextProps, nextState) => nextProps.reloadGraph;
+    shouldComponentUpdate = (nextProps) => nextProps.reloadGraph;
 
     render = () => {
-        if (this.props.data.nodes && this.props.data.nodes.length > 0) {
-            return (
-                <Graph
-                    id={this.props.id}
-                    data={this.props.data}
-                    config={this.props.config}
-                    onClickNode={this.props.onClickNode}
-                    onRightClickNode={this.props.onRightClickNode}
-                    onClickGraph={this.props.onClickGraph}
-                    onClickLink={this.props.onClickLink}
-                    onRightClickLink={this.props.onRightClickNode}
-                    onMouseOverNode={this.props.onMouseOverNode}
-                    onMouseOutNode={this.props.onMouseOutNode}
-                    onMouseOverLink={this.props.onMouseOverLink}
-                    onMouseOutLink={this.props.onMouseOutLink}
-                />
-            );
+        const {data, ...otherProps} = this.props;
+
+        // Finding distinct links
+        const links = [];
+        if (data.links) {
+            data.links.forEach((link) => {
+                const linkMatches = links.find(
+                    (existingEdge) => existingEdge.source === link.source && existingEdge.target === link.target);
+                if (!linkMatches) {
+                    links.push({
+                        source: link.source,
+                        target: link.target
+                    });
+                }
+            });
         }
-        return (<div>Nothing to show</div>);
+
+        let view;
+        if (data.nodes && data.nodes.length > 0) {
+            view = (
+                <ErrorBoundary title={"Unable to Render"} description={"Unable to Render due to Invalid Data"}>
+                    <Graph {...otherProps} data={{...data, links: links}}/>
+                </ErrorBoundary>
+            );
+        } else {
+            view = <div>No Data Available</div>;
+        }
+        return view;
     };
 
 }
 
 DependencyGraph.propTypes = {
-    id: PropTypes.string.isRequired,
     data: PropTypes.object.isRequired,
-    config: PropTypes.object.isRequired,
-    onClickNode: PropTypes.func,
-    onRightClickNode: PropTypes.func,
-    onClickGraph: PropTypes.func,
-    onClickLink: PropTypes.func,
-    onRightClickLink: PropTypes.func,
-    onMouseOverNode: PropTypes.func,
-    onMouseOutNode: PropTypes.func,
-    onMouseOverLink: PropTypes.func,
-    onMouseOutLink: PropTypes.func,
     reloadGraph: PropTypes.bool
 };
 

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/SidePanelContent.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/SidePanelContent.js
@@ -27,10 +27,10 @@ import ExpansionPanel from "@material-ui/core/ExpansionPanel";
 import ExpansionPanelDetails from "@material-ui/core/ExpansionPanelDetails";
 import ExpansionPanelSummary from "@material-ui/core/ExpansionPanelSummary";
 import Grey from "@material-ui/core/colors/grey";
+import HttpUtils from "../common/utils/httpUtils";
 import IconButton from "@material-ui/core/IconButton";
 import {Link} from "react-router-dom";
 import MUIDataTable from "mui-datatables";
-import PropTypes from "prop-types";
 import React from "react";
 import StateHolder from "../common/state/stateHolder";
 import SvgIcon from "@material-ui/core/SvgIcon";
@@ -43,18 +43,11 @@ import Timeline from "@material-ui/icons/Timeline";
 import Typography from "@material-ui/core/Typography";
 import withGlobalState from "../common/state";
 import {withStyles} from "@material-ui/core/styles";
-import {
-    Hint,
-    HorizontalBarSeries,
-    HorizontalGridLines,
-    VerticalGridLines,
-    XAxis,
-    XYPlot,
-    YAxis
-} from "react-vis";
+import {Hint, HorizontalBarSeries, HorizontalGridLines, VerticalGridLines, XAxis, XYPlot, YAxis} from "react-vis";
 import withColor, {ColorGenerator} from "../common/color";
+import * as PropTypes from "prop-types";
 
-const styles = (theme) => ({
+const styles = () => ({
     drawerContent: {
         padding: 20
     },
@@ -172,7 +165,7 @@ class SidePanelContent extends React.Component {
     }
 
     render = () => {
-        const {classes, summary, request, isOverview, colorGenerator, globalState, listData} = this.props;
+        const {classes, summary, request, selectedCell, colorGenerator, globalState, listData} = this.props;
         const {trafficTooltip} = this.state;
         const options = {
             download: false,
@@ -201,15 +194,22 @@ class SidePanelContent extends React.Component {
             },
             {
                 options: {
-                    customBodyRender: (value) => <Typography component={Link} className={classes.sidebarListTableText}
-                        to={`/cells/${value}`}>{value}</Typography>
+                    customBodyRender: (datum) => {
+                        const {cell, microservice} = datum;
+                        return (
+                            <Typography component={Link} className={classes.sidebarListTableText}
+                                to={`/cells/${cell}${microservice ? `/microservices/${microservice}` : ""}`}>
+                                {microservice ? microservice : cell}
+                            </Typography>
+                        );
+                    }
                 }
             },
             {
                 options: {
-                    customBodyRender: (value) => (
-                        // TODO : Change the to URL specific cell trace search
-                        <IconButton size="small" color="inherit" component={Link} to="/tracing/search">
+                    customBodyRender: (datum) => (
+                        <IconButton size="small" color="inherit" component={Link}
+                            to={`/tracing/search${HttpUtils.generateQueryParamString(datum)}`}>
                             <Timeline/>
                         </IconButton>
                     )
@@ -217,114 +217,157 @@ class SidePanelContent extends React.Component {
             }
         ];
 
-        const BarSeries = HorizontalBarSeries;
-
+        const successColor = colorGenerator.getColor(ColorGenerator.SUCCESS);
+        const warningColor = colorGenerator.getColor(ColorGenerator.WARNING);
+        const errorColor = colorGenerator.getColor(ColorGenerator.ERROR);
+        const unknownColor = colorGenerator.getColor(ColorGenerator.UNKNOWN);
         return (
             <div className={classes.drawerContent}>
                 <div className={classes.sidebarContainer}>
-                    {isOverview === true
-                        ? null
-                        : <div className={classes.cellNameContainer}>
-                            <CellIcon className={classes.titleIcon} fontSize="small"/>
-                            <Typography color="inherit"
-                                className={classes.sideBarContentTitle}> Cell:</Typography>
-                            {/* TODO : Change the to URL cell value and cell name to selected cell*/}
-                            <Typography component={Link} to={"/cells/cell1"} className={classes.cellName}>
-                                {summary.topic}</Typography>
-                        </div>
+                    {
+                        selectedCell
+                            ? (
+                                <div className={classes.cellNameContainer}>
+                                    <CellIcon className={classes.titleIcon} fontSize="small"/>
+                                    <Typography color="inherit" className={classes.sideBarContentTitle}>
+                                        Cell:
+                                    </Typography>
+                                    <Typography component={Link} to={`/cells/${selectedCell}`}
+                                        className={classes.cellName}>
+                                        {summary.topic}
+                                    </Typography>
+                                </div>
+                            )
+                            : null
                     }
                     <HttpTrafficIcon className={classes.titleIcon} fontSize="small"/>
-                    <Typography color="inherit" className={classes.sideBarContentTitle}>
-                        HTTP Traffic
-                    </Typography>
-
+                    <Typography color="inherit" className={classes.sideBarContentTitle}>HTTP Traffic</Typography>
                     <Table className={classes.table}>
                         <TableHead>
                             <TableRow>
                                 <TableCell className={classes.sidebarTableCell}>Requests/s</TableCell>
-                                {request.statusCodes[1].value === 0
-                                    ? null
-                                    : <TableCell className={classes.sidebarTableCell}><Avatar
-                                        className={classes.avatar}
-                                        style={{
-                                            backgroundColor: colorGenerator.getColor(ColorGenerator.SUCCESS)
-                                        }}>OK</Avatar></TableCell>}
-                                {request.statusCodes[2].value === 0
-                                    ? null
-                                    : <TableCell className={classes.sidebarTableCell}><Avatar
-                                        className={classes.avatar}
-                                        style={{
-                                            backgroundColor: colorGenerator.getColor(ColorGenerator.CLIENT_ERROR)
-                                        }}>3xx</Avatar></TableCell>}
-                                {request.statusCodes[3].value === 0
-                                    ? null
-                                    : <TableCell className={classes.sidebarTableCell}><Avatar
-                                        className={classes.avatar}
-                                        style={{
-                                            backgroundColor: colorGenerator.getColor(ColorGenerator.WARNING)
-                                        }}>4xx</Avatar></TableCell>}
-                                {request.statusCodes[4].value === 0
-                                    ? null
-                                    : <TableCell className={classes.sidebarTableCell}><Avatar
-                                        className={classes.avatar}
-                                        style={{
-                                            backgroundColor: colorGenerator.getColor(ColorGenerator.ERROR)
-                                        }}>5xx</Avatar></TableCell>}
-                                {request.statusCodes[5].value === 0
-                                    ? null
-                                    : <TableCell className={classes.sidebarTableCell}><Avatar
-                                        className={classes.avatar}
-                                        style={{
-                                            backgroundColor: colorGenerator.getColor(ColorGenerator.UNKNOWN)
-                                        }}>xxx</Avatar></TableCell>}
+                                {
+                                    request.statusCodes[1].value === 0
+                                        ? null
+                                        : (
+                                            <TableCell className={classes.sidebarTableCell}>
+                                                <Avatar className={classes.avatar}
+                                                    style={{backgroundColor: successColor}}>
+                                                    OK
+                                                </Avatar>
+                                            </TableCell>
+                                        )
+                                }
+                                {
+                                    request.statusCodes[2].value === 0
+                                        ? null
+                                        : (
+                                            <TableCell className={classes.sidebarTableCell}>
+                                                <Avatar className={classes.avatar}
+                                                    style={{backgroundColor: successColor}}>
+                                                    3xx
+                                                </Avatar>
+                                            </TableCell>
+                                        )
+                                }
+                                {
+                                    request.statusCodes[3].value === 0
+                                        ? null
+                                        : (
+                                            <TableCell className={classes.sidebarTableCell}>
+                                                <Avatar className={classes.avatar}
+                                                    style={{backgroundColor: warningColor}}>
+                                                    4xx
+                                                </Avatar>
+                                            </TableCell>
+                                        )
+                                }
+                                {
+                                    request.statusCodes[4].value === 0
+                                        ? null
+                                        : (
+                                            <TableCell className={classes.sidebarTableCell}>
+                                                <Avatar className={classes.avatar}
+                                                    style={{backgroundColor: errorColor}}>
+                                                    5xx
+                                                </Avatar>
+                                            </TableCell>
+                                        )
+                                }
+                                {
+                                    request.statusCodes[5].value === 0
+                                        ? null
+                                        : (
+                                            <TableCell className={classes.sidebarTableCell}>
+                                                <Avatar className={classes.avatar}
+                                                    style={{backgroundColor: unknownColor}}>
+                                                    xxx
+                                                </Avatar>
+                                            </TableCell>
+                                        )
+                                }
                             </TableRow>
                         </TableHead>
                         <TableBody>
                             <TableRow>
-                                <TableCell
-                                    className={classes.sidebarTableCell}>
-                                    {request.statusCodes[0].value}</TableCell>
-                                {request.statusCodes[1].value === 0
-                                    ? null
-                                    : <TableCell className={classes.sidebarTableCell}>
-                                        {request.statusCodes[1].value}%</TableCell>}
-                                {request.statusCodes[2].value === 0
-                                    ? null
-                                    : <TableCell
-                                        className={classes.sidebarTableCell}>
-                                        {request.statusCodes[2].value}%</TableCell>}
-                                {request.statusCodes[3].value === 0
-                                    ? null
-                                    : <TableCell
-                                        className={classes.sidebarTableCell}>
-                                        {request.statusCodes[3].value}%</TableCell>}
-                                {request.statusCodes[4].value === 0
-                                    ? null
-                                    : <TableCell
-                                        className={classes.sidebarTableCell}>
-                                        {request.statusCodes[4].value}%</TableCell>}
-                                {request.statusCodes[5].value === 0
-                                    ? null
-                                    : <TableCell
-                                        className={classes.sidebarTableCell}>
-                                        {request.statusCodes[5].value}%</TableCell>}
+                                <TableCell className={classes.sidebarTableCell}>
+                                    {request.statusCodes[0].value}
+                                </TableCell>
+                                {
+                                    request.statusCodes[1].value === 0
+                                        ? null
+                                        : (
+                                            <TableCell className={classes.sidebarTableCell}>
+                                                {request.statusCodes[1].value}%
+                                            </TableCell>
+                                        )
+                                }
+                                {
+                                    request.statusCodes[2].value === 0
+                                        ? null
+                                        : (
+                                            <TableCell className={classes.sidebarTableCell}>
+                                                {request.statusCodes[2].value}%
+                                            </TableCell>
+                                        )
+                                }
+                                {
+                                    request.statusCodes[3].value === 0
+                                        ? null
+                                        : (
+                                            <TableCell className={classes.sidebarTableCell}>
+                                                {request.statusCodes[3].value}%
+                                            </TableCell>
+                                        )
+                                }
+                                {
+                                    request.statusCodes[4].value === 0
+                                        ? null
+                                        : (
+                                            <TableCell className={classes.sidebarTableCell}>
+                                                {request.statusCodes[4].value}%
+                                            </TableCell>
+                                        )
+                                }
+                                {
+                                    request.statusCodes[5].value === 0
+                                        ? null
+                                        : (
+                                            <TableCell className={classes.sidebarTableCell}>
+                                                {request.statusCodes[5].value}%
+                                            </TableCell>
+                                        )
+                                }
                             </TableRow>
                         </TableBody>
                     </Table>
                     <div className={classes.barChart}>
-                        <XYPlot
-                            yType="ordinal"
-                            stackBy="x"
-                            width={250}
-                            height={isOverview === true
-                                ? 80
-                                : 100}>
+                        <XYPlot yType="ordinal" stackBy="x" width={250} height={selectedCell ? 100 : 80}>
                             <VerticalGridLines/>
                             <HorizontalGridLines/>
                             <XAxis/>
                             <YAxis/>
-                            <BarSeries
-                                color={colorGenerator.getColor(ColorGenerator.SUCCESS)}
+                            <HorizontalBarSeries color={successColor}
                                 data={[
                                     {
                                         y: "Total", x: request.statusCodes[1].value, title: request.statusCodes[1].key,
@@ -332,10 +375,9 @@ class SidePanelContent extends React.Component {
                                     }
                                 ]}
                                 onValueMouseOver={(v) => this.setState({trafficTooltip: v})}
-                                onSeriesMouseOut={(v) => this.setState({trafficTooltip: false})}
+                                onSeriesMouseOut={() => this.setState({trafficTooltip: false})}
                             />
-                            <BarSeries
-                                color={colorGenerator.getColor(ColorGenerator.CLIENT_ERROR)}
+                            <HorizontalBarSeries color={errorColor}
                                 data={[
                                     {
                                         y: "Total", x: request.statusCodes[2].value, title: request.statusCodes[2].key,
@@ -343,10 +385,9 @@ class SidePanelContent extends React.Component {
                                     }
                                 ]}
                                 onValueMouseOver={(v) => this.setState({trafficTooltip: v})}
-                                onSeriesMouseOut={(v) => this.setState({trafficTooltip: false})}
+                                onSeriesMouseOut={() => this.setState({trafficTooltip: false})}
                             />
-                            <BarSeries
-                                color={colorGenerator.getColor(ColorGenerator.WARNING)}
+                            <HorizontalBarSeries color={warningColor}
                                 data={[
                                     {
                                         y: "Total", x: request.statusCodes[3].value, title: request.statusCodes[3].key,
@@ -354,10 +395,9 @@ class SidePanelContent extends React.Component {
                                     }
                                 ]}
                                 onValueMouseOver={(v) => this.setState({trafficTooltip: v})}
-                                onSeriesMouseOut={(v) => this.setState({trafficTooltip: false})}
+                                onSeriesMouseOut={() => this.setState({trafficTooltip: false})}
                             />
-                            <BarSeries
-                                color={colorGenerator.getColor(ColorGenerator.ERROR)}
+                            <HorizontalBarSeries color={errorColor}
                                 data={[
                                     {
                                         y: "Total", x: request.statusCodes[4].value, title: request.statusCodes[4].key,
@@ -365,10 +405,9 @@ class SidePanelContent extends React.Component {
                                     }
                                 ]}
                                 onValueMouseOver={(v) => this.setState({trafficTooltip: v})}
-                                onSeriesMouseOut={(v) => this.setState({trafficTooltip: false})}
+                                onSeriesMouseOut={() => this.setState({trafficTooltip: false})}
                             />
-                            <BarSeries
-                                color={colorGenerator.getColor(ColorGenerator.UNKNOWN)}
+                            <HorizontalBarSeries color={unknownColor}
                                 data={[
                                     {
                                         y: "Total", x: request.statusCodes[5].value, title: request.statusCodes[5].key,
@@ -376,49 +415,71 @@ class SidePanelContent extends React.Component {
                                     }
                                 ]}
                                 onValueMouseOver={(v) => this.setState({trafficTooltip: v})}
-                                onSeriesMouseOut={(v) => this.setState({trafficTooltip: false})}
+                                onSeriesMouseOut={() => this.setState({trafficTooltip: false})}
                             />
-                            {trafficTooltip && <Hint value={trafficTooltip}>
-                                <div className="rv-hint__content">
-                                    {`${trafficTooltip.title} :
-                                    ${trafficTooltip.percentage}% (${trafficTooltip.count})`}
-                                </div>
-                            </Hint>}
+                            {
+                                trafficTooltip
+                                    ? (
+                                        <Hint value={trafficTooltip}>
+                                            <div className="rv-hint__content">
+                                                {`${trafficTooltip.title} :
+                                                ${trafficTooltip.percentage}% (${trafficTooltip.count})`}
+                                            </div>
+                                        </Hint>
+                                    )
+                                    : null
+                            }
                         </XYPlot>
                     </div>
                 </div>
                 <div className={classes.sidebarContainer}>
-                    {isOverview === true
-                        ? <CellsIcon className={classes.titleIcon} fontSize="small"/>
-                        : <MicroserviceIcon className={classes.titleIcon} fontSize="small"/>}
+                    {
+                        selectedCell
+                            ? <MicroserviceIcon className={classes.titleIcon} fontSize="small"/>
+                            : <CellsIcon className={classes.titleIcon} fontSize="small"/>
+                    }
                     <Typography color="inherit" className={classes.sideBarContentTitle}>
-                        {isOverview === true
-                            ? "Cells"
-                            : "Microservices"} ({summary.content[0].value})
+                        {selectedCell ? "Microservices" : "Cells"} ({summary.content[0].value})
                     </Typography>
                     <ExpansionPanel className={classes.panel}>
-                        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon/>}
-                            className={classes.expansionSum}>
-                            {summary.content[1].value === 0
-                                ? null
-                                : <Typography className={classes.secondaryHeading}><CheckCircleOutline
-                                    className={classes.cellIcon}
-                                    style={{
-                                        color: colorGenerator.getColor(ColorGenerator.SUCCESS)
-                                    }}/> {summary.content[1].value}
-                                </Typography>}
-                            {summary.content[2].value === 0
-                                ? null
-                                : <Typography className={classes.secondaryHeading}><ErrorIcon
-                                    className={classes.cellIcon}
-                                    style={{
-                                        color: colorGenerator.getColor(ColorGenerator.ERROR)
-                                    }}/> {summary.content[2].value}
-                                </Typography>}
+                        <ExpansionPanelSummary expandIcon={<ExpandMoreIcon/>} className={classes.expansionSum}>
+                            {
+                                summary.content[1].value === 0
+                                    ? null
+                                    : (
+                                        <Typography className={classes.secondaryHeading}>
+                                            <CheckCircleOutline className={classes.cellIcon}
+                                                style={{color: successColor}}/>
+                                            {summary.content[1].value}
+                                        </Typography>
+                                    )
+                            }
+                            {
+                                summary.content[2].value === 0
+                                    ? null
+                                    : (
+                                        <Typography className={classes.secondaryHeading}>
+                                            <ErrorIcon className={classes.cellIcon} style={{color: errorColor}}/>
+                                            {summary.content[2].value}
+                                        </Typography>
+                                    )
+                            }
                         </ExpansionPanelSummary>
                         <ExpansionPanelDetails className={classes.panelDetails}>
                             <div className="overviewSidebarListTable">
-                                <MUIDataTable columns={columns} data={listData} options={options}/>
+                                <MUIDataTable columns={columns} options={options}
+                                    data={listData.map((datum) => [
+                                        datum[0],
+                                        {
+                                            cell: selectedCell ? selectedCell.id : datum[1],
+                                            microservice: selectedCell ? datum[1] : null
+
+                                        },
+                                        {
+                                            cell: selectedCell ? selectedCell.id : datum[2],
+                                            microservice: selectedCell ? datum[2] : null
+                                        }
+                                    ])}/>
                             </div>
                         </ExpansionPanelDetails>
                     </ExpansionPanel>
@@ -434,7 +495,9 @@ SidePanelContent.propTypes = {
     colorGenerator: PropTypes.instanceOf(ColorGenerator).isRequired,
     summary: PropTypes.object.isRequired,
     request: PropTypes.object.isRequired,
-    isOverview: PropTypes.bool.isRequired,
+    selectedCell: PropTypes.shape({
+        id: PropTypes.string.isRequired
+    }),
     listData: PropTypes.arrayOf(PropTypes.any).isRequired,
     globalState: PropTypes.instanceOf(StateHolder).isRequired
 };

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/SidePanelContent.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/SidePanelContent.js
@@ -232,7 +232,7 @@ class SidePanelContent extends React.Component {
                                     <Typography color="inherit" className={classes.sideBarContentTitle}>
                                         Cell:
                                     </Typography>
-                                    <Typography component={Link} to={`/cells/${selectedCell}`}
+                                    <Typography component={Link} to={`/cells/${selectedCell.id}`}
                                         className={classes.cellName}>
                                         {summary.topic}
                                     </Typography>

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/index.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/index.js
@@ -42,7 +42,6 @@ const graphConfig = {
     directed: true,
     automaticRearrangeAfterDropNode: false,
     collapsible: false,
-    height: 800,
     highlightDegree: 1,
     highlightOpacity: 0.2,
     linkHighlightBehavior: false,
@@ -51,7 +50,8 @@ const graphConfig = {
     nodeHighlightBehavior: true,
     panAndZoom: false,
     staticGraph: false,
-    width: 1400,
+    height: 700,
+    width: 1050,
     d3: {
         alphaTarget: 0.05,
         gravity: -1500,

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/index.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/index.js
@@ -26,7 +26,6 @@ import IconButton from "@material-ui/core/IconButton";
 import MoreIcon from "@material-ui/icons/MoreHoriz";
 import NotificationUtils from "../common/utils/notificationUtils";
 import Paper from "@material-ui/core/Paper";
-import PropTypes from "prop-types";
 import QueryUtils from "../common/utils/queryUtils";
 import React from "react";
 import SidePanelContent from "./SidePanelContent";
@@ -37,6 +36,7 @@ import classNames from "classnames";
 import withGlobalState from "../common/state";
 import {withStyles} from "@material-ui/core/styles";
 import withColor, {ColorGenerator} from "../common/color";
+import * as PropTypes from "prop-types";
 
 const graphConfig = {
     directed: true,
@@ -245,7 +245,7 @@ class Overview extends React.Component {
                 data: {...prevState.data},
                 listData: serviceInfo,
                 reloadGraph: false,
-                isOverallSummary: false,
+                selectedCell: cell,
                 request: {
                     ...prevState.request,
                     statusCodes: statusCodeContent
@@ -287,7 +287,7 @@ class Overview extends React.Component {
             summary: defaultState.summary,
             listData: this.loadCellInfo(defaultState.data.nodes),
             reloadGraph: true,
-            isOverallSummary: true,
+            selectedCell: null,
             request: defaultState.request
         }));
     };
@@ -378,7 +378,7 @@ class Overview extends React.Component {
                 cellStats: []
             },
             healthInfo: [],
-            isOverallSummary: true,
+            selectedCell: null,
             data: {
                 nodes: null,
                 links: null
@@ -404,14 +404,15 @@ class Overview extends React.Component {
                 method: "GET"
             },
             this.props.globalState
-        ).then((response) => {
-            const result = response;
-            this.defaultState.healthInfo = this.getCellHealth(result.nodes);
+        ).then((result) => {
+            const {nodes, edges} = result;
+
+            this.defaultState.healthInfo = this.getCellHealth(nodes);
             const healthCount = this.getHealthCount(this.defaultState.healthInfo);
             const summaryContent = [
                 {
                     key: "Total",
-                    value: result.nodes.length
+                    value: nodes.length
                 },
                 {
                     key: "Successful",
@@ -427,14 +428,14 @@ class Overview extends React.Component {
                 }
             ];
             this.defaultState.summary.content = summaryContent;
-            this.defaultState.data.nodes = result.nodes;
-            this.defaultState.data.links = result.edges;
-            colorGenerator.addKeys(result.nodes);
-            const cellList = this.loadCellInfo(result.nodes);
+            this.defaultState.data.nodes = nodes;
+            this.defaultState.data.links = edges;
+            colorGenerator.addKeys(nodes);
+            const cellList = this.loadCellInfo(nodes);
             this.setState((prevState) => ({
                 data: {
-                    nodes: result.nodes,
-                    links: result.edges
+                    nodes: nodes,
+                    links: edges
                 },
                 summary: {
                     ...prevState.summary,
@@ -615,7 +616,7 @@ class Overview extends React.Component {
 
     render() {
         const {classes, theme} = this.props;
-        const {open} = this.state;
+        const {open, selectedCell} = this.state;
 
         return (
             <React.Fragment>
@@ -663,17 +664,16 @@ class Overview extends React.Component {
                                 {theme.direction === "rtl" ? <ChevronLeftIcon/> : <ChevronRightIcon/>}
                             </IconButton>
                             <Typography color="textSecondary" className={classes.sideBarHeading}>
-                                {(this.state.isOverallSummary) ? "Overview" : "Cell Details"}
+                                {selectedCell ? "Cell Details" : "Overview"}
                             </Typography>
                         </div>
                         <Divider/>
                         <SidePanelContent
                             summary={this.state.summary}
                             request={this.state.request}
-                            isOverview={this.state.isOverallSummary}
+                            selectedCell={selectedCell}
                             open={this.state.open}
-                            listData={this.state.listData}>
-                        </SidePanelContent>
+                            listData={this.state.listData}/>
                     </Drawer>
                 </div>
             </React.Fragment>

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/index.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/overview/index.js
@@ -38,53 +38,6 @@ import {withStyles} from "@material-ui/core/styles";
 import withColor, {ColorGenerator} from "../common/color";
 import * as PropTypes from "prop-types";
 
-const graphConfig = {
-    directed: true,
-    automaticRearrangeAfterDropNode: false,
-    collapsible: false,
-    highlightDegree: 1,
-    highlightOpacity: 0.2,
-    linkHighlightBehavior: false,
-    maxZoom: 8,
-    minZoom: 0.1,
-    nodeHighlightBehavior: true,
-    panAndZoom: false,
-    staticGraph: false,
-    height: 700,
-    width: 1050,
-    d3: {
-        alphaTarget: 0.05,
-        gravity: -1500,
-        linkLength: 150,
-        linkStrength: 1
-    },
-    node: {
-        color: "#d3d3d3",
-        fontColor: "black",
-        fontSize: 18,
-        fontWeight: "normal",
-        highlightColor: "red",
-        highlightFontSize: 18,
-        highlightFontWeight: "bold",
-        highlightStrokeColor: "SAME",
-        highlightStrokeWidth: 1.5,
-        labelProperty: "name",
-        mouseCursor: "pointer",
-        opacity: 1,
-        renderLabel: true,
-        size: 600,
-        strokeColor: "green",
-        strokeWidth: 2
-    },
-    link: {
-        color: "#d3d3d3",
-        opacity: 1,
-        semanticStrokeWidth: false,
-        strokeWidth: 4,
-        highlightColor: "black"
-    }
-};
-
 const drawerWidth = 300;
 
 const styles = (theme) => ({
@@ -345,7 +298,6 @@ class Overview extends React.Component {
         super(props);
         this.initializeDefault();
         this.state = JSON.parse(JSON.stringify(this.defaultState));
-        graphConfig.node.viewGenerator = this.viewGenerator;
     }
 
     initializeDefault = () => {
@@ -649,44 +601,31 @@ class Overview extends React.Component {
         return (
             <React.Fragment>
                 <TopToolbar title={"Overview"} onUpdate={this.loadOverviewOnTimeUpdate}/>
-
                 <div className={classes.root}>
-                    <Paper
-                        className={classNames(classes.content, {
-                            [classes.contentShift]: open
-                        })}
-                    >
-                        <DependencyGraph
-                            id="graph-id"
-                            data={this.state.data}
-                            config={graphConfig}
-                            reloadGraph={this.state.reloadGraph}
-                            onClickNode={this.onClickCell}
-                            onClickGraph={this.onClickGraph}
-                        />
+                    <Paper className={classNames(classes.content, {
+                        [classes.contentShift]: open
+                    })}>
+                        <DependencyGraph id="graph-id" data={this.state.data} reloadGraph={this.state.reloadGraph}
+                            onClickNode={this.onClickCell} onClickGraph={this.onClickGraph}
+                            config={{
+                                node: {
+                                    viewGenerator: this.viewGenerator
+                                }
+                            }}/>
                     </Paper>
                     <div className={classNames(classes.moreDetails, {
                         [classes.moreDetailsShift]: open
                     })}>
-                        <IconButton
-                            color="inherit"
-                            aria-label="Open drawer"
-                            onClick={this.handleDrawerOpen}
-                            className={classNames(classes.menuButton, open && classes.hide)}
-                        >
+                        <IconButton color="inherit" aria-label="Open drawer" onClick={this.handleDrawerOpen}
+                            className={classNames(classes.menuButton, open && classes.hide)}>
                             <MoreIcon/>
                         </IconButton>
                     </div>
 
-                    <Drawer
-                        className={classes.drawer}
-                        variant="persistent"
-                        anchor="right"
-                        open={open}
+                    <Drawer className={classes.drawer} variant="persistent" anchor="right" open={open}
                         classes={{
                             paper: classes.drawerPaper
-                        }}
-                    >
+                        }}>
                         <div className={classes.drawerHeader}>
                             <IconButton onClick={this.handleDrawerClose}>
                                 {theme.direction === "rtl" ? <ChevronLeftIcon/> : <ChevronRightIcon/>}
@@ -696,12 +635,8 @@ class Overview extends React.Component {
                             </Typography>
                         </div>
                         <Divider/>
-                        <SidePanelContent
-                            summary={this.state.summary}
-                            request={this.state.request}
-                            selectedCell={selectedCell}
-                            open={this.state.open}
-                            listData={this.state.listData}/>
+                        <SidePanelContent summary={this.state.summary} request={this.state.request}
+                            selectedCell={selectedCell} open={this.state.open} listData={this.state.listData}/>
                     </Drawer>
                 </div>
             </React.Fragment>

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/tracing/Search.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/tracing/Search.js
@@ -537,7 +537,8 @@ class Search extends React.Component {
             .filter((microservice) => selectedCells.includes(microservice.cell))
             .map((microservice) => microservice.name);
 
-        const selectedMicroservice = (filter.microservice && availableMicroservices.includes(filter.microservice))
+        const selectedMicroservice = data.cells.length === 0 || (filter.microservice
+            && availableMicroservices.includes(filter.microservice))
             ? filter.microservice
             : Search.ALL_VALUE;
 
@@ -549,7 +550,8 @@ class Search extends React.Component {
             .filter((operation) => selectedMicroservices.includes(operation.microservice))
             .map((operation) => operation.name);
 
-        const selectedOperation = (filter.operation && availableOperations.includes(filter.operation))
+        const selectedOperation = data.cells.length === 0 || (filter.operation
+            && availableOperations.includes(filter.operation))
             ? filter.operation
             : Search.ALL_VALUE;
 

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/tracing/view/DependencyDiagram.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/tracing/view/DependencyDiagram.js
@@ -119,6 +119,8 @@ class DependencyDiagram extends React.Component {
                             directed: true,
                             nodeHighlightBehavior: true,
                             highlightOpacity: 0.2,
+                            height: 700,
+                            width: 1100,
                             node: {
                                 fontSize: 15,
                                 highlightFontSize: 15,

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/tracing/view/index.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/tracing/view/index.js
@@ -78,7 +78,6 @@ class View extends React.Component {
 
     componentWillUnmount() {
         const {globalState} = this.props;
-
         globalState.removeListener(StateHolder.LOADING_STATE, this.handleLoadingStateChange);
     }
 
@@ -183,8 +182,12 @@ class View extends React.Component {
                         <Tab label="Dependency Diagram"/>
                     </Tabs>
                     <ErrorBoundary title={"Unable to render Invalid Trace"}>
-                        <SelectedTabContent spans={spans} innerRef={this.traceViewRef}
-                            selectedMicroservice={selectedMicroservice}/>
+                        {
+                            isLoading
+                                ? null
+                                : <SelectedTabContent spans={spans} innerRef={this.traceViewRef}
+                                    selectedMicroservice={selectedMicroservice}/>
+                        }
                     </ErrorBoundary>
                 </Paper>
             );
@@ -195,14 +198,10 @@ class View extends React.Component {
         }
 
         return (
-            isLoading
-                ? null
-                : (
-                    <React.Fragment>
-                        <TopToolbar title={"Distributed Tracing"}/>
-                        {view}
-                    </React.Fragment>
-                )
+            <React.Fragment>
+                <TopToolbar title={"Distributed Tracing"}/>
+                {view}
+            </React.Fragment>
         );
     };
 

--- a/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/tracing/view/index.js
+++ b/system/control-plane/global/components/observability/org.wso2.vick.observability.ui/src/pages/tracing/view/index.js
@@ -181,14 +181,16 @@ class View extends React.Component {
                         <Tab label="Sequence Diagram"/>
                         <Tab label="Dependency Diagram"/>
                     </Tabs>
-                    <ErrorBoundary title={"Unable to render Invalid Trace"}>
-                        {
-                            isLoading
-                                ? null
-                                : <SelectedTabContent spans={spans} innerRef={this.traceViewRef}
-                                    selectedMicroservice={selectedMicroservice}/>
-                        }
-                    </ErrorBoundary>
+                    {
+                        isLoading
+                            ? null
+                            : (
+                                <ErrorBoundary title={"Unable to render Invalid Trace"}>
+                                    <SelectedTabContent spans={spans} innerRef={this.traceViewRef}
+                                        selectedMicroservice={selectedMicroservice}/>
+                                </ErrorBoundary>
+                            )
+                    }
                 </Paper>
             );
         } else if (errorMessage) {

--- a/system/control-plane/global/docker-files/am/Dockerfile
+++ b/system/control-plane/global/docker-files/am/Dockerfile
@@ -18,9 +18,13 @@
 
 FROM wso2vick/wso2am:base
 
+ARG USER_HOME=/home/wso2carbon
+ARG FILES=./target/files
+
 # Copy the jar files
-COPY ./target/files/dropins/** /home/wso2carbon/wso2am-2.6.0/repository/components/dropins/
-COPY ./target/files/lib/** /home/wso2carbon/wso2am-2.6.0/repository/components/lib/
+COPY --chown=wso2carbon:wso2 ${FILES}/dropins/** ${USER_HOME}/wso2am-2.6.0/repository/components/dropins/
+COPY --chown=wso2carbon:wso2 ${FILES}/lib/** ${USER_HOME}/wso2am-2.6.0/repository/components/lib/
 
 # Copying the STS Web App
-COPY ./target/files/webapps/** /home/wso2carbon/wso2am-2.6.0/repository/deployment/server/webapps
+COPY --chown=wso2carbon:wso2 ${FILES}/webapps/** ${USER_HOME}/wso2am-2.6.0/repository/deployment/server/webapps/
+COPY --chown=wso2carbon:wso2 ${FILES}/webapps/** ${USER_HOME}/wso2-tmp/server/webapps/


### PR DESCRIPTION
## Purpose
> Adding Quick Access Links between pages. 

## Goals
> Add and fix the links from the overview, cell and microservice pages to other pages to quickly search traces or access cell or microservice pages. This also contains several fixes to some bugs

## Approach
> The relevant links were updated and some bugs were fixed

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
>NPM v.6.5.0
 
## Learning
> N/A