### PR TITLE
Enabling mTLS: Create destination rules for cell gateways

### DIFF
--- a/system/controller/pkg/apis/istio/networking/v1alpha3/virtual_service_types.go
+++ b/system/controller/pkg/apis/istio/networking/v1alpha3/virtual_service_types.go
@@ -235,7 +235,7 @@ type PortSelector struct {
 	// Types that are valid to be assigned to Port:
 	//	*PortSelector_Number
 	//	*PortSelector_Name
-	Number string `json:"number,omitempty"`
+	Number uint32 `json:"number,omitempty"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/system/controller/pkg/controller/gateway/resources/meta.go
+++ b/system/controller/pkg/controller/gateway/resources/meta.go
@@ -66,3 +66,7 @@ func IstioIngressVirtualServiceName(gateway *v1alpha1.Gateway) string {
 func GatewayFullK8sServiceName(gateway *v1alpha1.Gateway) string {
 	return GatewayK8sServiceName(gateway) + "." + gateway.Namespace
 }
+
+func IstioDestinationRuleName(gateway *v1alpha1.Gateway) string {
+	return gateway.Name + "-destination-rule"
+}


### PR DESCRIPTION
Enabling mTLS: Create destination rules for cell gateways to make mutual authentication mandatory on port 443